### PR TITLE
Override tracker URL suffix

### DIFF
--- a/projects/tracker/src/lib/configuration.ts
+++ b/projects/tracker/src/lib/configuration.ts
@@ -53,6 +53,9 @@ export interface MatomoTrackerConfiguration {
 
   /** Matomo server url */
   trackerUrl: string;
+
+  /** The trackerUrlSuffix is always appended to the trackerUrl. It defaults to matomo.php */
+  trackerUrlSuffix?: string;
 }
 
 export interface MultiTrackersConfiguration {
@@ -145,5 +148,11 @@ export function getTrackersConfiguration(
 ): MatomoTrackerConfiguration[] {
   return isMultiTrackerConfiguration(config)
     ? config.trackers
-    : [{ trackerUrl: config.trackerUrl, siteId: config.siteId }];
+    : [
+        {
+          trackerUrl: config.trackerUrl,
+          siteId: config.siteId,
+          trackerUrlSuffix: config.trackerUrlSuffix,
+        },
+      ];
 }

--- a/projects/tracker/src/lib/matomo-initializer.service.spec.ts
+++ b/projects/tracker/src/lib/matomo-initializer.service.spec.ts
@@ -289,6 +289,42 @@ describe('MatomoInitializerService', () => {
     expect(tracker.addTracker).toHaveBeenCalledTimes(2);
   });
 
+  it('should append custom tracker suffix if configured, matomo.php otherwise', () => {
+    // Given
+    let injectedScript: HTMLScriptElement | undefined;
+    const service = instantiate({
+      trackers: [
+        { siteId: 'site1', trackerUrl: 'http://fakeTrackerUrl1', trackerUrlSuffix: '' },
+        {
+          siteId: 'site2',
+          trackerUrl: 'http://fakeTrackerUrl2',
+          trackerUrlSuffix: '/custom-tracker.php',
+        },
+        { siteId: 'site3', trackerUrl: 'http://fakeTrackerUrl3' },
+      ],
+    });
+    const tracker = TestBed.inject(MatomoTracker);
+
+    spyOn(tracker, 'setTrackerUrl');
+    spyOn(tracker, 'setSiteId');
+    spyOn(tracker, 'addTracker');
+    setUpScriptInjection(script => (injectedScript = script));
+
+    // When
+    service.init();
+
+    // Then
+    expectInjectedScript(injectedScript, 'http://fakeTrackerUrl1/matomo.js');
+    expect(tracker.setTrackerUrl).toHaveBeenCalledOnceWith('http://fakeTrackerUrl1');
+    expect(tracker.setSiteId).toHaveBeenCalledOnceWith('site1');
+    expect(tracker.addTracker).toHaveBeenCalledWith(
+      'http://fakeTrackerUrl2/custom-tracker.php',
+      'site2'
+    );
+    expect(tracker.addTracker).toHaveBeenCalledWith('http://fakeTrackerUrl3/matomo.php', 'site3');
+    expect(tracker.addTracker).toHaveBeenCalledTimes(2);
+  });
+
   it('should do nothing when disabled', () => {
     // Given
     let injectedScript: HTMLScriptElement | undefined;


### PR DESCRIPTION
Add option `trackerUrlSuffix` which allows to override the `matomo.php` suffix which is automatically appended to the `trackerUrl` config option

fixes EmmanuelRoux/ngx-matomo#24