### PR TITLE
fix(tracker): add option to override the matomo.php suffix which is a…

### DIFF
--- a/projects/tracker/src/lib/configuration.ts
+++ b/projects/tracker/src/lib/configuration.ts
@@ -1,4 +1,5 @@
 import { inject, InjectFlags, InjectionToken } from '@angular/core';
+
 import { requireNonNull } from './coercion';
 
 const CONFIG_NOT_FOUND =
@@ -53,6 +54,9 @@ export interface MatomoTrackerConfiguration {
 
   /** Matomo server url */
   trackerUrl: string;
+
+  /** The trackerUrlSuffix is always appended to the trackerUrl. It defaults to matomo.php */
+  trackerUrlSuffix?: string;
 }
 
 export interface MultiTrackersConfiguration {
@@ -145,5 +149,11 @@ export function getTrackersConfiguration(
 ): MatomoTrackerConfiguration[] {
   return isMultiTrackerConfiguration(config)
     ? config.trackers
-    : [{ trackerUrl: config.trackerUrl, siteId: config.siteId }];
+    : [
+        {
+          trackerUrl: config.trackerUrl,
+          siteId: config.siteId,
+          trackerUrlSuffix: config.trackerUrlSuffix,
+        },
+      ];
 }

--- a/projects/tracker/src/lib/matomo-initializer.service.spec.ts
+++ b/projects/tracker/src/lib/matomo-initializer.service.spec.ts
@@ -1,11 +1,9 @@
 import { Injector } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
+
 import {
-  InternalMatomoConfiguration,
-  MATOMO_CONFIGURATION,
-  MatomoConfiguration,
-  MatomoConsentMode,
-  MatomoInitializationMode,
+    InternalMatomoConfiguration, MATOMO_CONFIGURATION, MatomoConfiguration, MatomoConsentMode,
+    MatomoInitializationMode
 } from './configuration';
 import { MatomoHolder } from './holder';
 import { MatomoInitializerService } from './matomo-initializer.service';
@@ -264,6 +262,42 @@ describe('MatomoInitializerService', () => {
     expect(tracker.setTrackerUrl).toHaveBeenCalledOnceWith('http://fakeTrackerUrl1/matomo.php');
     expect(tracker.setSiteId).toHaveBeenCalledOnceWith('site1');
     expect(tracker.addTracker).toHaveBeenCalledWith('http://fakeTrackerUrl2/matomo.php', 'site2');
+    expect(tracker.addTracker).toHaveBeenCalledWith('http://fakeTrackerUrl3/matomo.php', 'site3');
+    expect(tracker.addTracker).toHaveBeenCalledTimes(2);
+  });
+
+  it('should append custom tracker suffix if configured, matomo.php otherwise', () => {
+    // Given
+    let injectedScript: HTMLScriptElement | undefined;
+    const service = instantiate({
+      trackers: [
+        { siteId: 'site1', trackerUrl: 'http://fakeTrackerUrl1', trackerUrlSuffix: '' },
+        {
+          siteId: 'site2',
+          trackerUrl: 'http://fakeTrackerUrl2',
+          trackerUrlSuffix: '/custom-tracker.php',
+        },
+        { siteId: 'site3', trackerUrl: 'http://fakeTrackerUrl3' },
+      ],
+    });
+    const tracker = TestBed.inject(MatomoTracker);
+
+    spyOn(tracker, 'setTrackerUrl');
+    spyOn(tracker, 'setSiteId');
+    spyOn(tracker, 'addTracker');
+    setUpScriptInjection(script => (injectedScript = script));
+
+    // When
+    service.init();
+
+    // Then
+    expectInjectedScript(injectedScript, 'http://fakeTrackerUrl1/matomo.js');
+    expect(tracker.setTrackerUrl).toHaveBeenCalledOnceWith('http://fakeTrackerUrl1');
+    expect(tracker.setSiteId).toHaveBeenCalledOnceWith('site1');
+    expect(tracker.addTracker).toHaveBeenCalledWith(
+      'http://fakeTrackerUrl2/custom-tracker.php',
+      'site2'
+    );
     expect(tracker.addTracker).toHaveBeenCalledWith('http://fakeTrackerUrl3/matomo.php', 'site3');
     expect(tracker.addTracker).toHaveBeenCalledTimes(2);
   });


### PR DESCRIPTION
…utomatically appended to the trackerUrl [cherry pick similar commit bd93470e478e4e90d15ded5f7c15e981de481cd8 made on main branch]