### PR TITLE
fix(router): retrieve Base Href from LocationStrategy instead

### DIFF
--- a/projects/ngx-matomo-client/router/page-url-provider.spec.ts
+++ b/projects/ngx-matomo-client/router/page-url-provider.spec.ts
@@ -89,4 +89,24 @@ describe('PageUrlProvider', () => {
       expect(url).toEqual('/my-page');
     });
   });
+
+  it('should return page url when base href is null', () => {
+    // Given
+    const provider = instantiate(
+      {
+        /* prependBaseHref: true */
+      },
+      null,
+    );
+    const locationStrategy = TestBed.inject(LocationStrategy);
+
+    // @ts-expect-error Bug in angular in which sometimes a null value is returned despite typing
+    spyOn(locationStrategy, 'getBaseHref').and.returnValue(null);
+
+    // When
+    provider.getCurrentPageUrl(new NavigationEnd(0, '/my-page', '/my-page')).subscribe(url => {
+      // Then
+      expect(url).toEqual('/my-page');
+    });
+  });
 });

--- a/projects/ngx-matomo-client/router/page-url-provider.spec.ts
+++ b/projects/ngx-matomo-client/router/page-url-provider.spec.ts
@@ -1,4 +1,4 @@
-import { APP_BASE_HREF, PlatformLocation } from '@angular/common';
+import { APP_BASE_HREF, LocationStrategy } from '@angular/common';
 import { TestBed } from '@angular/core/testing';
 import { NavigationEnd } from '@angular/router';
 import { MATOMO_CONFIGURATION, MatomoConfiguration } from 'ngx-matomo-client/core';
@@ -57,7 +57,7 @@ describe('PageUrlProvider', () => {
     });
   });
 
-  it('should return page url prepended with DOM base href', () => {
+  it('should return page url prepended with LocationStrategy base href', () => {
     // Given
     const provider = instantiate(
       {
@@ -65,9 +65,9 @@ describe('PageUrlProvider', () => {
       },
       null,
     );
-    const platform = TestBed.inject(PlatformLocation);
+    const locationStrategy = TestBed.inject(LocationStrategy);
 
-    spyOn(platform, 'getBaseHrefFromDOM').and.returnValue('/test');
+    spyOn(locationStrategy, 'getBaseHref').and.returnValue('/test');
 
     // When
     provider.getCurrentPageUrl(new NavigationEnd(0, '/my-page', '/my-page')).subscribe(url => {
@@ -79,9 +79,9 @@ describe('PageUrlProvider', () => {
   it('should return page url without base href', () => {
     // Given
     const provider = instantiate({ prependBaseHref: false }, '/test/');
-    const platform = TestBed.inject(PlatformLocation);
+    const locationStrategy = TestBed.inject(LocationStrategy);
 
-    spyOn(platform, 'getBaseHrefFromDOM').and.returnValue('/test');
+    spyOn(locationStrategy, 'getBaseHref').and.returnValue('/test');
 
     // When
     provider.getCurrentPageUrl(new NavigationEnd(0, '/my-page', '/my-page')).subscribe(url => {

--- a/projects/ngx-matomo-client/router/page-url-provider.ts
+++ b/projects/ngx-matomo-client/router/page-url-provider.ts
@@ -1,4 +1,4 @@
-import { APP_BASE_HREF, PlatformLocation } from '@angular/common';
+import { APP_BASE_HREF, LocationStrategy } from '@angular/common';
 import { inject, InjectionToken } from '@angular/core';
 import { NavigationEnd } from '@angular/router';
 import { Observable, of } from 'rxjs';
@@ -11,7 +11,7 @@ export const MATOMO_PAGE_URL_PROVIDER = new InjectionToken<PageUrlProvider>(
       new DefaultPageUrlProvider(
         inject(INTERNAL_ROUTER_CONFIGURATION),
         inject(APP_BASE_HREF, { optional: true }),
-        inject(PlatformLocation),
+        inject(LocationStrategy),
       ),
   },
 );
@@ -28,7 +28,7 @@ export class DefaultPageUrlProvider implements PageUrlProvider {
   constructor(
     private readonly config: InternalRouterConfiguration,
     private readonly baseHref: string | null,
-    private readonly platformLocation: PlatformLocation,
+    private readonly locationStrategy: LocationStrategy,
   ) {}
 
   getCurrentPageUrl(event: NavigationEnd): Observable<string> {
@@ -40,6 +40,6 @@ export class DefaultPageUrlProvider implements PageUrlProvider {
   }
 
   private getBaseHrefWithoutTrailingSlash(): string {
-    return trimTrailingSlash(this.baseHref ?? this.platformLocation.getBaseHrefFromDOM());
+    return trimTrailingSlash(this.baseHref ?? this.locationStrategy.getBaseHref());
   }
 }

--- a/projects/ngx-matomo-client/router/page-url-provider.ts
+++ b/projects/ngx-matomo-client/router/page-url-provider.ts
@@ -40,6 +40,6 @@ export class DefaultPageUrlProvider implements PageUrlProvider {
   }
 
   private getBaseHrefWithoutTrailingSlash(): string {
-    return trimTrailingSlash(this.baseHref ?? this.locationStrategy.getBaseHref());
+    return trimTrailingSlash(this.baseHref ?? this.locationStrategy.getBaseHref() ?? '');
   }
 }


### PR DESCRIPTION
Attempt to resolve #82.
Unfortunately, does not solve the exception as it still gets a null-value for the base href, but at least it does not call PlatformLocation anymore.