### PR TITLE
fix(router): subsequent navigation to the same url should not trigger…

### DIFF
--- a/projects/ngx-matomo-client/router/matomo-router.service.spec.ts
+++ b/projects/ngx-matomo-client/router/matomo-router.service.spec.ts
@@ -295,6 +295,21 @@ describe('MatomoRouter', () => {
     expect(tracker.setReferrerUrl).not.toHaveBeenCalled();
   }));
 
+  it('should not track page view if navigated to the same url with query params', fakeAsync(() => {
+    // Given
+    const service = instantiate({}, { enableLinkTracking: false });
+    const tracker = TestBed.inject(MatomoTracker) as jasmine.SpyObj<MatomoTracker>;
+
+    // When
+    service.initialize();
+    triggerEvent('/test');
+    triggerEvent('/test?page=1');
+    tick(); // Tracking is asynchronous by default
+
+    // Then
+    expect(tracker.trackPageView).toHaveBeenCalledTimes(1);
+  }));
+
   it('should call interceptors if any and wait for them to resolve', fakeAsync(() => {
     // Given
     const interceptor1 = jasmine.createSpyObj<MatomoRouterInterceptor>('interceptor1', [

--- a/projects/ngx-matomo-client/router/matomo-router.service.spec.ts
+++ b/projects/ngx-matomo-client/router/matomo-router.service.spec.ts
@@ -7,6 +7,7 @@ import {
   InternalGlobalConfiguration,
   MATOMO_ROUTER_CONFIGURATION,
   MatomoRouterConfiguration,
+  NavigationEndComparator,
 } from './configuration';
 import { invalidInterceptorsProviderError } from './errors';
 import { MATOMO_ROUTER_INTERCEPTORS, MatomoRouterInterceptor } from './interceptor';
@@ -295,9 +296,32 @@ describe('MatomoRouter', () => {
     expect(tracker.setReferrerUrl).not.toHaveBeenCalled();
   }));
 
+  it('should track page view if navigated to the same url with different query params', fakeAsync(() => {
+    // Given
+    const service = instantiate(
+      {
+        navigationEndComparator: 'fullUrl',
+      },
+      { enableLinkTracking: false },
+    );
+    const tracker = TestBed.inject(MatomoTracker) as jasmine.SpyObj<MatomoTracker>;
+
+    // When
+    service.initialize();
+    triggerEvent('/test');
+    triggerEvent('/test?page=1');
+    tick(); // Tracking is asynchronous by default
+
+    // Then
+    expect(tracker.trackPageView).toHaveBeenCalledTimes(2);
+  }));
+
   it('should not track page view if navigated to the same url with query params', fakeAsync(() => {
     // Given
-    const service = instantiate({}, { enableLinkTracking: false });
+    const service = instantiate(
+      { navigationEndComparator: 'ignoreQueryParams' },
+      { enableLinkTracking: false },
+    );
     const tracker = TestBed.inject(MatomoTracker) as jasmine.SpyObj<MatomoTracker>;
 
     // When
@@ -308,6 +332,42 @@ describe('MatomoRouter', () => {
 
     // Then
     expect(tracker.trackPageView).toHaveBeenCalledTimes(1);
+  }));
+
+  it('should not track page view if navigated to the "same" url, as configured from custom NavigationEndComparator', fakeAsync(() => {
+    // Given
+    const isEvenPageParam = (url: string) => {
+      const params = new URL(url, 'http://localhost').searchParams;
+      const page = Number(params.get('page') ?? 0);
+
+      return page % 2 === 0;
+    };
+    const myCustomComparator: NavigationEndComparator = (
+      previousNavigationEnd,
+      currentNavigationEnd,
+    ) => {
+      return (
+        isEvenPageParam(previousNavigationEnd.urlAfterRedirects) ===
+        isEvenPageParam(currentNavigationEnd.urlAfterRedirects)
+      );
+    };
+    const service = instantiate(
+      {
+        navigationEndComparator: myCustomComparator,
+      },
+      { enableLinkTracking: false },
+    );
+    const tracker = TestBed.inject(MatomoTracker) as jasmine.SpyObj<MatomoTracker>;
+
+    // When
+    service.initialize();
+    triggerEvent('/test?page=1');
+    triggerEvent('/test?page=2');
+    triggerEvent('/test?page=4');
+    tick(); // Tracking is asynchronous by default
+
+    // Then
+    expect(tracker.trackPageView).toHaveBeenCalledTimes(2);
   }));
 
   it('should call interceptors if any and wait for them to resolve', fakeAsync(() => {

--- a/projects/ngx-matomo-client/router/public-api.ts
+++ b/projects/ngx-matomo-client/router/public-api.ts
@@ -9,6 +9,7 @@ export {
   MATOMO_ROUTER_CONFIGURATION,
   ExclusionConfig,
   MatomoRouterConfigurationWithInterceptors,
+  NavigationEndComparator,
 } from './configuration';
 export { PageTitleProvider, MATOMO_PAGE_TITLE_PROVIDER } from './page-title-providers';
 export { PageUrlProvider, MATOMO_PAGE_URL_PROVIDER } from './page-url-provider';


### PR DESCRIPTION
I am trying to fix #72. I am not sure if my approach is acceptable. I am not sure how PageUrlProvider could be used. location.pathname also contains the pathname without the queryparam.
If my understanding is correct then the previous distinctUntilKeyChanged('urlAfterRedirects') was deadcode because if user navigates to the same url NavigationEnd event is not triggered only NavigationSkipped.
