### PR TITLE
Disable page tracking on server

### DIFF
--- a/projects/ngx-matomo-client/form-analytics/matomo-form-analytics-initializer.service.spec.ts
+++ b/projects/ngx-matomo-client/form-analytics/matomo-form-analytics-initializer.service.spec.ts
@@ -1,4 +1,5 @@
-import { Provider } from '@angular/core';
+import { ɵPLATFORM_SERVER_ID } from '@angular/common';
+import { PLATFORM_ID, Provider } from '@angular/core';
 import { fakeAsync, TestBed, tick } from '@angular/core/testing';
 import {
   AutoMatomoConfiguration,
@@ -214,5 +215,26 @@ describe('MatomoFormAnalyticsInitializer', () => {
 
     await initializer.initialize();
     expect(formAnalytics.disableFormAnalytics).toHaveBeenCalledTimes(1);
+  });
+
+  it('should implicitly disable form analytics when not running in browser', async () => {
+    // Given
+    const pageViewTracked = new Subject<void>();
+    const initializer = await instantiate(
+      {},
+      {},
+      [{ provide: PLATFORM_ID, useValue: ɵPLATFORM_SERVER_ID }],
+      pageViewTracked,
+    );
+    const formAnalytics = TestBed.inject(MatomoFormAnalytics);
+
+    await initializer.initialize();
+    expect(formAnalytics.scanForForms).not.toHaveBeenCalled();
+
+    // When
+    pageViewTracked.next();
+    // Then
+    expect(formAnalytics.scanForForms).not.toHaveBeenCalled();
+    expect(formAnalytics.disableFormAnalytics).not.toHaveBeenCalled();
   });
 });

--- a/projects/ngx-matomo-client/form-analytics/matomo-form-analytics-initializer.service.ts
+++ b/projects/ngx-matomo-client/form-analytics/matomo-form-analytics-initializer.service.ts
@@ -1,4 +1,5 @@
-import { inject, Injectable, OnDestroy } from '@angular/core';
+import { isPlatformBrowser } from '@angular/common';
+import { inject, Injectable, OnDestroy, PLATFORM_ID } from '@angular/core';
 import {
   MatomoTracker,
   ɵappendTrailingSlash as appendTrailingSlash,
@@ -24,6 +25,7 @@ export class MatomoFormAnalyticsInitializer implements OnDestroy {
   private readonly scriptInjector = inject(ScriptInjector);
   private readonly tracker = inject(MatomoTracker);
   private readonly formAnalytics = inject(MatomoFormAnalytics);
+  private readonly platformId = inject(PLATFORM_ID);
 
   private pageTrackedSubscription: Subscription | undefined;
 
@@ -32,6 +34,11 @@ export class MatomoFormAnalyticsInitializer implements OnDestroy {
   }
 
   readonly initialize = runOnce(async () => {
+    // Do not set-up router if running on server
+    if (!isPlatformBrowser(this.platformId)) {
+      return;
+    }
+
     if (this.config.disabled) {
       this.formAnalytics.disableFormAnalytics();
       return;

--- a/projects/ngx-matomo-client/router/matomo-router.service.ts
+++ b/projects/ngx-matomo-client/router/matomo-router.service.ts
@@ -1,4 +1,5 @@
-import { Inject, Injectable, Optional } from '@angular/core';
+import { isPlatformBrowser } from '@angular/common';
+import { Inject, Injectable, Optional, PLATFORM_ID } from '@angular/core';
 import { Event, NavigationEnd, Router } from '@angular/router';
 import { MatomoTracker, ɵrunOnce as runOnce } from 'ngx-matomo-client/core';
 import {
@@ -79,6 +80,8 @@ function getNavigationEndComparator(config: InternalRouterConfiguration): Naviga
 export class MatomoRouter {
   constructor(
     private readonly router: Router,
+    @Inject(PLATFORM_ID)
+    private readonly platformId: object,
     @Inject(INTERNAL_ROUTER_CONFIGURATION)
     private readonly config: InternalRouterConfiguration,
     @Inject(MATOMO_PAGE_TITLE_PROVIDER)
@@ -101,8 +104,8 @@ export class MatomoRouter {
   }
 
   readonly initialize = runOnce(() => {
-    if (this.config.disabled) {
-      // Do not set-up router if globally disabled
+    if (this.config.disabled || !isPlatformBrowser(this.platformId)) {
+      // Do not set-up router if globally disabled or running on server
       return;
     }
 


### PR DESCRIPTION
## The Problem

I've been using this package for various Angular projects, both with client-only and server-side rendering. However, I encountered an error where the server throws an error saying `navigator` is not defined.

This happens when I attempt to get the current language in an interceptor to add it as a custom dimension:

```ts
export const languageInterceptor: MatomoRouterInterceptorFn = () => {
  const tracker = inject(MatomoTracker);

  // This only works in the browser, because `navigator` is not defined on the server
  tracker.setCustomDimension(1, navigator.language);
}
```

While adding an `isPlatformBrowser` check to the interceptor would solve this, the README states:

> **Can I use ngx-matomo-client with Server-side rendering (SSR) / Angular Universal?**
> Yes. ngx-matomo-client automatically disables itself on non-browser platforms.

So, it seems like the interceptor shouldn't be executed on the server at all.

## The Fix

Upon investigating, I found that:

- The `core` package correctly checks the platform to initialize the tracker.
- However, `MatomoRouter` does not skip initializing itself on the server and continues listening to router events and executing interceptors, leading to the error.

To align with the README, I have modified `MatomoRouter` to also skip initialization when running on the server.

## Testing

I added two new test scenarios to cover both `'browser'` and `'server'` `PLATFORM_ID` values used by Angular. Both tests now pass as expected, confirming that the changes work correctly in both environments.

_Unfortunately Angular doesn't export the `PLATFORM_ID`s via a proper API but only with the internal `ɵ` prefix. Nevertheless I thought it's better to use them than hard-coding the strings just in case they might change the values in the future._

~~I haven't been able to test these changes in my project because I'm unsure how to install a local version without deploying it to npm.~~

Please let me know if this fix is acceptable or if the current behavior was indeed intended.