### PR TITLE
fix(lazyload): move 'root' provider to provideMatomo

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -139,10 +139,7 @@
     }
   },
   "cli": {
-    "schematicCollections": [
-      "@angular-eslint/schematics"
-    ],
-    "analytics": false
+    "schematicCollections": ["@angular-eslint/schematics"]
   },
   "schematics": {
     "@schematics/angular:directive": {

--- a/angular.json
+++ b/angular.json
@@ -139,7 +139,10 @@
     }
   },
   "cli": {
-    "schematicCollections": ["@angular-eslint/schematics"]
+    "schematicCollections": [
+      "@angular-eslint/schematics"
+    ],
+    "analytics": false
   },
   "schematics": {
     "@schematics/angular:directive": {

--- a/angular.json
+++ b/angular.json
@@ -27,7 +27,8 @@
           "options": {
             "main": "projects/ngx-matomo-client/test.ts",
             "tsConfig": "projects/ngx-matomo-client/tsconfig.spec.json",
-            "karmaConfig": "projects/ngx-matomo-client/karma.conf.js"
+            "karmaConfig": "projects/ngx-matomo-client/karma.conf.js",
+            "codeCoverageExclude": ["projects/ngx-matomo-client/core/testing/**"]
           }
         },
         "lint": {

--- a/projects/demo/src/app/app.component.spec.ts
+++ b/projects/demo/src/app/app.component.spec.ts
@@ -1,7 +1,7 @@
 import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
-import { MatomoConfiguration, MatomoRouterModule, MatomoModule } from 'ngx-matomo-client';
+import { MatomoModule, MatomoRouterModule } from 'ngx-matomo-client';
 import { AppComponent } from './app.component';
 
 describe('AppComponent', () => {
@@ -12,8 +12,8 @@ describe('AppComponent', () => {
         MatomoModule.forRoot({
           trackerUrl: '',
           siteId: '',
-        } as MatomoConfiguration),
-        MatomoRouterModule,
+        }),
+        MatomoRouterModule.forRoot(),
       ],
       declarations: [AppComponent],
       schemas: [NO_ERRORS_SCHEMA],

--- a/projects/ngx-matomo-client/core/directives/matomo-opt-out-form.component.spec.ts
+++ b/projects/ngx-matomo-client/core/directives/matomo-opt-out-form.component.spec.ts
@@ -1,17 +1,13 @@
-import { ApplicationInitStatus, Component, LOCALE_ID } from '@angular/core';
+import { Component, LOCALE_ID } from '@angular/core';
 import { fakeAsync, flush, TestBed } from '@angular/core/testing';
 import { By, DomSanitizer, SafeResourceUrl } from '@angular/platform-browser';
-import { provideMatomoTesting } from '../../testing';
 import { provideMatomo } from '../providers';
 import { provideTestingTracker } from '../testing/testing-tracker';
 import {
   ASYNC_INTERNAL_MATOMO_CONFIGURATION,
   INTERNAL_MATOMO_CONFIGURATION,
   InternalMatomoConfiguration,
-  MATOMO_CONFIGURATION,
-  MatomoConfiguration,
 } from '../tracker/configuration';
-import { MatomoInitializerService } from '../tracker/matomo-initializer.service';
 import { MatomoOptOutFormComponent } from './matomo-opt-out-form.component';
 
 @Component({

--- a/projects/ngx-matomo-client/core/directives/matomo-opt-out-form.component.spec.ts
+++ b/projects/ngx-matomo-client/core/directives/matomo-opt-out-form.component.spec.ts
@@ -1,6 +1,9 @@
-import { Component, LOCALE_ID } from '@angular/core';
+import { ApplicationInitStatus, Component, LOCALE_ID } from '@angular/core';
 import { fakeAsync, flush, TestBed } from '@angular/core/testing';
 import { By, DomSanitizer, SafeResourceUrl } from '@angular/platform-browser';
+import { provideMatomoTesting } from '../../testing';
+import { provideMatomo } from '../providers';
+import { provideTestingTracker } from '../testing/testing-tracker';
 import {
   ASYNC_INTERNAL_MATOMO_CONFIGURATION,
   INTERNAL_MATOMO_CONFIGURATION,
@@ -102,18 +105,14 @@ describe('MatomoOptOutFormComponent', () => {
         HostWithoutLocaleComponent,
       ],
       providers: [
-        {
-          provide: MATOMO_CONFIGURATION,
-          useValue: { siteId: 1, trackerUrl: 'http://localhost' } as MatomoConfiguration,
-        },
+        provideMatomo({ siteId: 1, trackerUrl: 'http://localhost' }),
+        provideTestingTracker(),
         {
           provide: LOCALE_ID,
           useValue: 'en',
         },
       ],
     }).compileComponents();
-
-    TestBed.inject(MatomoInitializerService).initialize();
   });
 
   it('should create', async () => {

--- a/projects/ngx-matomo-client/core/directives/matomo-opt-out-form.component.ts
+++ b/projects/ngx-matomo-client/core/directives/matomo-opt-out-form.component.ts
@@ -12,8 +12,6 @@ import {
 import { DomSanitizer, SafeResourceUrl } from '@angular/platform-browser';
 import {
   ASYNC_INTERNAL_MATOMO_CONFIGURATION,
-  AutoMatomoConfiguration,
-  ExplicitAutoConfiguration,
   getTrackersConfiguration,
   InternalMatomoConfiguration,
   isAutoConfigurationMode,
@@ -134,11 +132,6 @@ export class MatomoOptOutFormComponent implements OnInit, OnChanges {
     this.updateUrl();
 
     this.config.then(config => {
-      console.log(
-        'config',
-        config,
-        getTrackersConfiguration(config as ExplicitAutoConfiguration)[0].trackerUrl,
-      );
       if (isAutoConfigurationMode(config) && isExplicitTrackerConfiguration(config)) {
         this._defaultServerUrl = getTrackersConfiguration(config)[0].trackerUrl;
       }
@@ -167,7 +160,6 @@ export class MatomoOptOutFormComponent implements OnInit, OnChanges {
     if (this._serverUrlOverride) {
       serverUrl = this.sanitizer.sanitize(SecurityContext.RESOURCE_URL, this._serverUrlOverride);
     }
-    console.log('updateUrl', this._defaultServerUrl, serverUrl);
 
     if (!serverUrl) {
       if (this._defaultServerUrlInitialized) {

--- a/projects/ngx-matomo-client/core/directives/matomo-opt-out-form.component.ts
+++ b/projects/ngx-matomo-client/core/directives/matomo-opt-out-form.component.ts
@@ -12,6 +12,8 @@ import {
 import { DomSanitizer, SafeResourceUrl } from '@angular/platform-browser';
 import {
   ASYNC_INTERNAL_MATOMO_CONFIGURATION,
+  AutoMatomoConfiguration,
+  ExplicitAutoConfiguration,
   getTrackersConfiguration,
   InternalMatomoConfiguration,
   isAutoConfigurationMode,
@@ -132,6 +134,11 @@ export class MatomoOptOutFormComponent implements OnInit, OnChanges {
     this.updateUrl();
 
     this.config.then(config => {
+      console.log(
+        'config',
+        config,
+        getTrackersConfiguration(config as ExplicitAutoConfiguration)[0].trackerUrl,
+      );
       if (isAutoConfigurationMode(config) && isExplicitTrackerConfiguration(config)) {
         this._defaultServerUrl = getTrackersConfiguration(config)[0].trackerUrl;
       }
@@ -160,6 +167,7 @@ export class MatomoOptOutFormComponent implements OnInit, OnChanges {
     if (this._serverUrlOverride) {
       serverUrl = this.sanitizer.sanitize(SecurityContext.RESOURCE_URL, this._serverUrlOverride);
     }
+    console.log('updateUrl', this._defaultServerUrl, serverUrl);
 
     if (!serverUrl) {
       if (this._defaultServerUrlInitialized) {

--- a/projects/ngx-matomo-client/core/private-api.ts
+++ b/projects/ngx-matomo-client/core/private-api.ts
@@ -12,4 +12,8 @@ export {
   isAutoConfigurationMode as ɵisAutoConfigurationMode,
 } from './tracker/configuration';
 export { InternalMatomoTracker as ɵInternalMatomoTracker } from './tracker/internal-matomo-tracker.service';
+export {
+  provideTestingTracker as ɵprovideTestingTracker,
+  MatomoTestingTracker as ɵMatomoTestingTracker,
+} from './testing/testing-tracker';
 export { createMatomoFeature as ɵcreateMatomoFeature } from './providers';

--- a/projects/ngx-matomo-client/core/providers.spec.ts
+++ b/projects/ngx-matomo-client/core/providers.spec.ts
@@ -21,11 +21,11 @@ describe('providers', () => {
     const config: MatomoConfiguration = { trackerUrl: 'my-tracker', siteId: 42 };
 
     await setUp([
+      provideMatomo(config),
       {
         provide: MatomoInitializerService,
         useValue: fakeInitializer,
       },
-      provideMatomo(config),
     ]);
 
     expect(TestBed.inject(MatomoTracker)).toEqual(jasmine.any(MatomoTracker));
@@ -40,6 +40,7 @@ describe('providers', () => {
     const trackerUrlToken = new InjectionToken<string>('trackerUrl');
 
     await setUp([
+      provideMatomo(() => ({ trackerUrl: TestBed.inject(trackerUrlToken), siteId: 42 })),
       {
         provide: MatomoInitializerService,
         useValue: fakeInitializer,
@@ -48,7 +49,6 @@ describe('providers', () => {
         provide: trackerUrlToken,
         useValue: trackerUrl,
       },
-      provideMatomo(() => ({ trackerUrl: TestBed.inject(trackerUrlToken), siteId: 42 })),
     ]);
 
     expect(TestBed.inject(MatomoTracker)).toEqual(jasmine.any(MatomoTracker));

--- a/projects/ngx-matomo-client/core/providers.ts
+++ b/projects/ngx-matomo-client/core/providers.ts
@@ -23,11 +23,7 @@ import {
   MatomoInitializerService,
 } from './tracker/matomo-initializer.service';
 import { MatomoTracker } from './tracker/matomo-tracker.service';
-import {
-  createDefaultMatomoScriptElement,
-  MATOMO_SCRIPT_FACTORY,
-  MatomoScriptFactory,
-} from './tracker/script-factory';
+import { MATOMO_SCRIPT_FACTORY, MatomoScriptFactory } from './tracker/script-factory';
 import { ScriptInjector } from './utils/script-injector';
 
 const PRIVATE_MATOMO_PROVIDERS = Symbol('MATOMO_PROVIDERS');

--- a/projects/ngx-matomo-client/core/providers.ts
+++ b/projects/ngx-matomo-client/core/providers.ts
@@ -5,7 +5,15 @@ import {
   makeEnvironmentProviders,
   Provider,
 } from '@angular/core';
-import { MATOMO_CONFIGURATION, MatomoConfiguration } from './tracker/configuration';
+import {
+  ASYNC_INTERNAL_MATOMO_CONFIGURATION,
+  createDeferredInternalMatomoConfiguration,
+  createInternalMatomoConfiguration,
+  DEFERRED_INTERNAL_MATOMO_CONFIGURATION,
+  INTERNAL_MATOMO_CONFIGURATION,
+  MATOMO_CONFIGURATION,
+  MatomoConfiguration,
+} from './tracker/configuration';
 import {
   createInternalMatomoTracker,
   InternalMatomoTracker,
@@ -96,6 +104,18 @@ export function provideMatomo(
     {
       provide: MatomoInitializerService,
       useFactory: createMatomoInitializer,
+    },
+    {
+      provide: INTERNAL_MATOMO_CONFIGURATION,
+      useFactory: createInternalMatomoConfiguration,
+    },
+    {
+      provide: DEFERRED_INTERNAL_MATOMO_CONFIGURATION,
+      useFactory: createDeferredInternalMatomoConfiguration,
+    },
+    {
+      provide: ASYNC_INTERNAL_MATOMO_CONFIGURATION,
+      useFactory: () => inject(DEFERRED_INTERNAL_MATOMO_CONFIGURATION).configuration,
     },
     {
       provide: ENVIRONMENT_INITIALIZER,

--- a/projects/ngx-matomo-client/core/testing/testing-tracker.ts
+++ b/projects/ngx-matomo-client/core/testing/testing-tracker.ts
@@ -1,0 +1,57 @@
+import { ApplicationInitStatus, inject, Injectable, Provider } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import {
+  InternalMatomoTracker,
+  InternalMatomoTrackerType,
+} from '../tracker/internal-matomo-tracker.service';
+import { PrefixedType } from '../utils/types';
+
+export function provideTestingTracker(): Provider[] {
+  return [
+    MatomoTestingTracker,
+    {
+      provide: InternalMatomoTracker,
+      useExisting: MatomoTestingTracker,
+    },
+  ];
+}
+
+@Injectable()
+export class MatomoTestingTracker<MATOMO = unknown, PREFIX extends string = ''>
+  implements InternalMatomoTrackerType
+{
+  private readonly initStatus = inject(ApplicationInitStatus);
+
+  callsOnInit: unknown[][] = [];
+  callsAfterInit: unknown[][] = [];
+
+  get calls(): unknown[] {
+    return [...this.callsOnInit, ...this.callsAfterInit];
+  }
+
+  countCallsAfterInit(command: string): number {
+    return this.callsAfterInit.filter(call => call[0] === command).length;
+  }
+
+  reset() {
+    this.callsOnInit = [];
+    this.callsAfterInit = [];
+  }
+
+  /** Asynchronously call provided method name on matomo tracker instance */
+  async get<K extends keyof PrefixedType<MATOMO, PREFIX>>(_: K): Promise<never> {
+    return Promise.reject('MatomoTracker is disabled');
+  }
+
+  push(arg: unknown[]): void {
+    if (this.initStatus.done) {
+      this.callsAfterInit.push(arg);
+    } else {
+      this.callsOnInit.push(arg);
+    }
+  }
+
+  async pushFn<T>(_: (matomo: PrefixedType<MATOMO, PREFIX>) => T): Promise<T> {
+    return Promise.reject('MatomoTracker is disabled');
+  }
+}

--- a/projects/ngx-matomo-client/core/testing/testing-tracker.ts
+++ b/projects/ngx-matomo-client/core/testing/testing-tracker.ts
@@ -1,5 +1,4 @@
 import { ApplicationInitStatus, inject, Injectable, Provider } from '@angular/core';
-import { TestBed } from '@angular/core/testing';
 import {
   InternalMatomoTracker,
   InternalMatomoTrackerType,
@@ -22,9 +21,12 @@ export class MatomoTestingTracker<MATOMO = unknown, PREFIX extends string = ''>
 {
   private readonly initStatus = inject(ApplicationInitStatus);
 
+  /** Get list of all calls until initialization */
   callsOnInit: unknown[][] = [];
+  /** Get list of all calls after initialization */
   callsAfterInit: unknown[][] = [];
 
+  /** Get a copy of all calls since application startup */
   get calls(): unknown[] {
     return [...this.callsOnInit, ...this.callsAfterInit];
   }

--- a/projects/ngx-matomo-client/core/tracker/configuration.ts
+++ b/projects/ngx-matomo-client/core/tracker/configuration.ts
@@ -63,7 +63,7 @@ export function createDeferredInternalMatomoConfiguration(): DeferredInternalMat
       )({
         ...base,
         ...configuration,
-      } as InternalMatomoConfiguration);
+      });
     },
   };
 }
@@ -89,7 +89,7 @@ export type InternalMatomoConfiguration = Omit<MatomoConfiguration, 'mode' | 're
 export interface DeferredInternalMatomoConfiguration {
   readonly configuration: Promise<InternalMatomoConfiguration>;
 
-  markReady(configuration: AutoMatomoConfiguration<'auto' | 'deferred'>): void;
+  markReady(configuration: InternalMatomoConfiguration): void;
 }
 
 /**

--- a/projects/ngx-matomo-client/core/tracker/configuration.ts
+++ b/projects/ngx-matomo-client/core/tracker/configuration.ts
@@ -20,59 +20,53 @@ export const MATOMO_CONFIGURATION = new InjectionToken<MatomoConfiguration>('MAT
  */
 export const INTERNAL_MATOMO_CONFIGURATION = new InjectionToken<InternalMatomoConfiguration>(
   'INTERNAL_MATOMO_CONFIGURATION',
-  {
-    factory(): InternalMatomoConfiguration {
-      const { mode, requireConsent, ...restConfig } = requireNonNull(
-        inject(MATOMO_CONFIGURATION, { optional: true }),
-        CONFIG_NOT_FOUND,
-      );
-
-      return {
-        mode: mode ? coerceInitializationMode(mode) : undefined,
-        disabled: false,
-        enableLinkTracking: true,
-        trackAppInitialLoad: !inject(MATOMO_ROUTER_ENABLED),
-        requireConsent: requireConsent ? coerceConsentRequirement(requireConsent) : 'none',
-        enableJSErrorTracking: false,
-        runOutsideAngularZone: false,
-        disableCampaignParameters: false,
-        acceptDoNotTrack: false,
-        ...restConfig,
-      };
-    },
-  },
 );
+
+export function createInternalMatomoConfiguration(): InternalMatomoConfiguration {
+  const { mode, requireConsent, ...restConfig } = requireNonNull(
+    inject(MATOMO_CONFIGURATION, { optional: true }),
+    CONFIG_NOT_FOUND,
+  );
+
+  return {
+    mode: mode ? coerceInitializationMode(mode) : undefined,
+    disabled: false,
+    enableLinkTracking: true,
+    trackAppInitialLoad: !inject(MATOMO_ROUTER_ENABLED),
+    requireConsent: requireConsent ? coerceConsentRequirement(requireConsent) : 'none',
+    enableJSErrorTracking: false,
+    runOutsideAngularZone: false,
+    disableCampaignParameters: false,
+    acceptDoNotTrack: false,
+    ...restConfig,
+  };
+}
 
 /**
  * For internal use only. Injection token for deferred {@link InternalMatomoConfiguration}.
  *
  */
 export const DEFERRED_INTERNAL_MATOMO_CONFIGURATION =
-  new InjectionToken<DeferredInternalMatomoConfiguration>(
-    'DEFERRED_INTERNAL_MATOMO_CONFIGURATION',
-    {
-      factory: () => {
-        const base = inject(INTERNAL_MATOMO_CONFIGURATION);
-        let resolveFn: ((configuration: InternalMatomoConfiguration) => void) | undefined;
-        const configuration = new Promise<InternalMatomoConfiguration>(
-          resolve => (resolveFn = resolve),
-        );
+  new InjectionToken<DeferredInternalMatomoConfiguration>('DEFERRED_INTERNAL_MATOMO_CONFIGURATION');
 
-        return {
-          configuration,
-          markReady(configuration) {
-            requireNonNull(
-              resolveFn,
-              'resolveFn',
-            )({
-              ...base,
-              ...configuration,
-            } as InternalMatomoConfiguration);
-          },
-        };
-      },
+export function createDeferredInternalMatomoConfiguration(): DeferredInternalMatomoConfiguration {
+  const base = inject(INTERNAL_MATOMO_CONFIGURATION);
+  let resolveFn: ((configuration: InternalMatomoConfiguration) => void) | undefined;
+  const configuration = new Promise<InternalMatomoConfiguration>(resolve => (resolveFn = resolve));
+
+  return {
+    configuration,
+    markReady(configuration) {
+      requireNonNull(
+        resolveFn,
+        'resolveFn',
+      )({
+        ...base,
+        ...configuration,
+      } as InternalMatomoConfiguration);
     },
-  );
+  };
+}
 
 /**
  * For internal use only. Injection token for fully loaded async {@link InternalMatomoConfiguration}.
@@ -80,9 +74,7 @@ export const DEFERRED_INTERNAL_MATOMO_CONFIGURATION =
  */
 export const ASYNC_INTERNAL_MATOMO_CONFIGURATION = new InjectionToken<
   Promise<InternalMatomoConfiguration>
->('ASYNC_INTERNAL_MATOMO_CONFIGURATION', {
-  factory: () => inject(DEFERRED_INTERNAL_MATOMO_CONFIGURATION).configuration,
-});
+>('ASYNC_INTERNAL_MATOMO_CONFIGURATION');
 
 /**
  * For internal use only. Module configuration merged with default values.

--- a/projects/ngx-matomo-client/core/tracker/internal-matomo-tracker.service.ts
+++ b/projects/ngx-matomo-client/core/tracker/internal-matomo-tracker.service.ts
@@ -18,7 +18,7 @@ function trimTrailingUndefinedElements<T>(array: T[]): T[] {
   return trimmed;
 }
 
-type InternalMatomoTrackerType = Pick<
+export type InternalMatomoTrackerType = Pick<
   InternalMatomoTracker<unknown, string>,
   'get' | 'push' | 'pushFn'
 >;
@@ -67,6 +67,7 @@ export class InternalMatomoTracker<MATOMO, PREFIX extends string = ''> {
   }
 }
 
+@Injectable()
 export class NoopMatomoTracker<MATOMO = unknown, PREFIX extends string = ''>
   implements InternalMatomoTrackerType
 {

--- a/projects/ngx-matomo-client/core/tracker/internal-matomo-tracker.service.ts
+++ b/projects/ngx-matomo-client/core/tracker/internal-matomo-tracker.service.ts
@@ -30,10 +30,7 @@ export function createInternalMatomoTracker(): InternalMatomoTrackerType {
   return disabled || !isBrowser ? new NoopMatomoTracker() : new InternalMatomoTracker();
 }
 
-@Injectable({
-  providedIn: 'root',
-  useFactory: createInternalMatomoTracker,
-})
+@Injectable()
 export class InternalMatomoTracker<MATOMO, PREFIX extends string = ''> {
   private readonly ngZone = inject(NgZone);
   private readonly config = inject(INTERNAL_MATOMO_CONFIGURATION);

--- a/projects/ngx-matomo-client/core/tracker/matomo-initializer.service.spec.ts
+++ b/projects/ngx-matomo-client/core/tracker/matomo-initializer.service.spec.ts
@@ -1,322 +1,65 @@
-import { EnvironmentInjector, PLATFORM_ID, Provider } from '@angular/core';
-import { TestBed } from '@angular/core/testing';
-import { MatomoHolder } from '../holder';
-import { provideMatomo, withScriptFactory } from '../providers';
 import {
-  MATOMO_CONFIGURATION,
-  MATOMO_ROUTER_ENABLED,
-  MatomoConfiguration,
-  MatomoConsentMode,
-} from './configuration';
+  ApplicationInitStatus,
+  InjectionToken,
+  PLATFORM_ID,
+  Provider,
+  Signal,
+  WritableSignal,
+} from '@angular/core';
+import { toSignal } from '@angular/core/rxjs-interop';
+import { TestBed } from '@angular/core/testing';
+import { BehaviorSubject } from 'rxjs';
+import { MatomoHolder } from '../holder';
+import { MatomoFeature, provideMatomo, withScriptFactory } from '../providers';
+import { MatomoTestingTracker, provideTestingTracker } from '../testing/testing-tracker';
+import { MATOMO_ROUTER_ENABLED, MatomoConfiguration, MatomoConsentMode } from './configuration';
 import { ALREADY_INITIALIZED_ERROR, ALREADY_INJECTED_ERROR } from './errors';
 import { MatomoInitializerService } from './matomo-initializer.service';
-import { MatomoTracker } from './matomo-tracker.service';
-import {
-  createDefaultMatomoScriptElement,
-  MATOMO_SCRIPT_FACTORY,
-  MatomoScriptFactory,
-} from './script-factory';
+import { createDefaultMatomoScriptElement } from './script-factory';
 
 declare let window: MatomoHolder;
 
 describe('MatomoInitializerService', () => {
-  function instantiate(
+  const injectedScriptSpyToken = new InjectionToken<WritableSignal<HTMLScriptElement | undefined>>(
+    'injectedScriptSpyToken',
+  );
+
+  async function setUp(
     config: MatomoConfiguration,
     providers: Provider[] = [],
-  ): MatomoInitializerService {
+    features: MatomoFeature[] = [],
+  ): Promise<{
+    tracker: MatomoTestingTracker;
+    service: MatomoInitializerService;
+    injectedScript: Signal<HTMLScriptElement | undefined>;
+  }> {
+    const injectedScript = new BehaviorSubject<HTMLScriptElement | undefined>(undefined);
+
     TestBed.resetTestingModule();
+
     TestBed.configureTestingModule({
       providers: [
-        {
-          provide: MATOMO_CONFIGURATION,
-          useValue: config,
-        },
+        provideMatomo(config, ...features),
+        provideTestingTracker(),
         ...providers,
-      ],
-    });
-
-    return TestBed.inject(MatomoInitializerService);
-  }
-
-  beforeEach(() => delete (window as Partial<MatomoHolder>)._paq);
-
-  it('should register _paq global once', () => {
-    TestBed.configureTestingModule({
-      providers: [
         {
-          provide: MATOMO_CONFIGURATION,
-          useValue: {},
+          provide: injectedScriptSpyToken,
+          useFactory: () => toSignal(injectedScript),
         },
       ],
-    })
-      .inject(EnvironmentInjector)
-      .runInContext(() => {
-        // Given
-        expect(window._paq).toBeUndefined();
-
-        // When
-        new MatomoInitializerService();
-        // Then
-        expect(window._paq).toEqual([]);
-        const paq = window._paq;
-
-        // When
-        new MatomoInitializerService();
-        // Then
-        expect(window._paq).toEqual([]);
-        expect(window._paq).toBe(paq);
-      });
-  });
-
-  it('should track initial page view by default', () => {
-    // Given
-    const service = instantiate({
-      mode: 'manual',
-      enableLinkTracking: false,
     });
-    const tracker = TestBed.inject(MatomoTracker);
 
-    spyOn(tracker, 'trackPageView');
+    setUpScriptInjection(script => injectedScript.next(script));
 
-    // When
-    service.initialize();
+    // https://github.com/angular/angular/issues/24218
+    await TestBed.inject(ApplicationInitStatus).donePromise;
 
-    // Then
-    expect(tracker.trackPageView).toHaveBeenCalledOnceWith();
-  });
-
-  it('should not track initial page view by default if router is enabled', () => {
-    // Given
-    const service = instantiate(
-      {
-        mode: 'manual',
-        enableLinkTracking: false,
-      },
-      [{ provide: MATOMO_ROUTER_ENABLED, useValue: true }],
-    );
-    const tracker = TestBed.inject(MatomoTracker);
-
-    spyOn(tracker, 'trackPageView');
-
-    // When
-    service.initialize();
-
-    // Then
-    expect(tracker.trackPageView).not.toHaveBeenCalled();
-  });
-
-  it('should manually force track initial page view no matter router is enabled', () => {
-    // Given
-    const service = instantiate(
-      {
-        mode: 'manual',
-        trackAppInitialLoad: true,
-        enableLinkTracking: false,
-      },
-      [{ provide: MATOMO_ROUTER_ENABLED, useValue: true }],
-    );
-    const tracker = TestBed.inject(MatomoTracker);
-
-    spyOn(tracker, 'trackPageView');
-
-    // When
-    service.initialize();
-
-    // Then
-    expect(tracker.trackPageView).toHaveBeenCalledOnceWith();
-  });
-
-  it('should not track initial page view with manual configuration, no matter router enabled', () => {
-    // Given
-    const service = instantiate({
-      mode: 'manual',
-      enableLinkTracking: false,
-      trackAppInitialLoad: false,
-    });
-    const tracker = TestBed.inject(MatomoTracker);
-
-    spyOn(tracker, 'trackPageView');
-
-    // When
-    service.initialize();
-
-    // Then
-    expect(tracker.trackPageView).not.toHaveBeenCalled();
-  });
-
-  it('should enable link tracking with manual configuration', () => {
-    // Given
-    const service = instantiate({
-      mode: 'manual',
-      trackAppInitialLoad: false,
-      enableLinkTracking: true,
-    });
-    const tracker = TestBed.inject(MatomoTracker);
-
-    spyOn(tracker, 'enableLinkTracking');
-
-    // When
-    service.initialize();
-
-    // Then
-    expect(tracker.enableLinkTracking).toHaveBeenCalledOnceWith(false);
-  });
-
-  it('should enable link tracking using pseudo-clicks with manual configuration', () => {
-    // Given
-    const service = instantiate({
-      mode: 'manual',
-      trackAppInitialLoad: false,
-      enableLinkTracking: 'enable-pseudo',
-    });
-    const tracker = TestBed.inject(MatomoTracker);
-
-    spyOn(tracker, 'enableLinkTracking');
-
-    // When
-    service.initialize();
-
-    // Then
-    expect(tracker.enableLinkTracking).toHaveBeenCalledOnceWith(true);
-  });
-
-  it('should set Do Not Track setting if enabled', () => {
-    // Given
-    const service = instantiate({
-      mode: 'manual',
-      acceptDoNotTrack: true,
-      trackAppInitialLoad: true,
-      enableLinkTracking: false,
-    });
-    const tracker = TestBed.inject(MatomoTracker);
-
-    spyOn(tracker, 'trackPageView');
-    spyOn(tracker, 'setDoNotTrack');
-
-    // When
-    service.initialize();
-
-    // Then
-    expect(tracker.trackPageView).toHaveBeenCalledOnceWith();
-    expect(tracker.setDoNotTrack).toHaveBeenCalledOnceWith(true);
-    expect(tracker.setDoNotTrack).toHaveBeenCalledBefore(tracker.trackPageView);
-  });
-
-  it('should disable campaign parameters if enabled', () => {
-    // Given
-    const service = instantiate({
-      mode: 'manual',
-      disableCampaignParameters: true,
-      trackAppInitialLoad: true,
-      enableLinkTracking: false,
-    });
-    const tracker = TestBed.inject(MatomoTracker);
-
-    spyOn(tracker, 'trackPageView');
-    spyOn(tracker, 'disableCampaignParameters');
-
-    // When
-    service.initialize();
-
-    // Then
-    expect(tracker.trackPageView).toHaveBeenCalledOnceWith();
-    expect(tracker.disableCampaignParameters).toHaveBeenCalledTimes(1);
-    expect(tracker.disableCampaignParameters).toHaveBeenCalledBefore(tracker.trackPageView);
-  });
-
-  it('should require tracking consent if setting is enabled', () => {
-    for (const value of ['tracking', MatomoConsentMode.TRACKING] as const) {
-      // Given
-      const service = instantiate({
-        mode: 'manual',
-        requireConsent: value,
-        trackAppInitialLoad: true,
-        enableLinkTracking: false,
-      });
-      const tracker = TestBed.inject(MatomoTracker);
-
-      spyOn(tracker, 'trackPageView');
-      spyOn(tracker, 'requireConsent');
-
-      // When
-      service.initialize();
-
-      // Then
-      expect(tracker.trackPageView).toHaveBeenCalledOnceWith();
-      expect(tracker.requireConsent).toHaveBeenCalledOnceWith();
-      expect(tracker.requireConsent).toHaveBeenCalledBefore(tracker.trackPageView);
-    }
-  });
-
-  it('should require cookie consent if setting is enabled', () => {
-    for (const value of ['cookie', MatomoConsentMode.COOKIE] as const) {
-      // Given
-      const service = instantiate({
-        mode: 'manual',
-        requireConsent: value,
-        trackAppInitialLoad: true,
-        enableLinkTracking: false,
-      });
-      const tracker = TestBed.inject(MatomoTracker);
-
-      spyOn(tracker, 'trackPageView');
-      spyOn(tracker, 'requireCookieConsent');
-
-      // When
-      service.initialize();
-
-      // Then
-      expect(tracker.trackPageView).toHaveBeenCalledOnceWith();
-      expect(tracker.requireCookieConsent).toHaveBeenCalledOnceWith();
-      expect(tracker.requireCookieConsent).toHaveBeenCalledBefore(tracker.trackPageView);
-    }
-  });
-
-  it('should not require any consent if setting is not enabled', () => {
-    for (const value of ['none', MatomoConsentMode.NONE, undefined] as const) {
-      // Given
-      const service = instantiate({
-        mode: 'manual',
-        requireConsent: value,
-        trackAppInitialLoad: true,
-        enableLinkTracking: false,
-      });
-      const tracker = TestBed.inject(MatomoTracker);
-
-      spyOn(tracker, 'trackPageView');
-      spyOn(tracker, 'requireCookieConsent');
-      spyOn(tracker, 'requireConsent');
-
-      // When
-      service.initialize();
-
-      // Then
-      expect(tracker.trackPageView).toHaveBeenCalledOnceWith();
-      expect(tracker.requireCookieConsent).not.toHaveBeenCalled();
-      expect(tracker.requireConsent).not.toHaveBeenCalled();
-    }
-  });
-
-  it('should enable JS errors tracking if enabled', () => {
-    // Given
-    const service = instantiate({
-      mode: 'manual',
-      trackAppInitialLoad: true,
-      enableJSErrorTracking: true,
-    });
-    const tracker = TestBed.inject(MatomoTracker);
-
-    spyOn(tracker, 'trackPageView');
-    spyOn(tracker, 'enableJSErrorTracking');
-
-    // When
-    service.initialize();
-
-    // Then
-    expect(tracker.trackPageView).toHaveBeenCalledTimes(1);
-    expect(tracker.enableJSErrorTracking).toHaveBeenCalledTimes(1);
-    expect(tracker.enableJSErrorTracking).toHaveBeenCalledBefore(tracker.trackPageView);
-  });
+    return {
+      service: TestBed.inject(MatomoInitializerService),
+      tracker: TestBed.inject(MatomoTestingTracker),
+      injectedScript: TestBed.inject(injectedScriptSpyToken),
+    };
+  }
 
   function setUpScriptInjection(cb: (injectedScript: HTMLScriptElement) => void): void {
     const mockContainer = jasmine.createSpyObj<HTMLElement>('FakeContainer', ['insertBefore']);
@@ -330,136 +73,316 @@ describe('MatomoInitializerService', () => {
       return script;
     });
 
-    spyOn(window.document, 'getElementsByTagName').and.returnValue([
+    const getElementsByTagNameSpy = jasmine.isSpy(window.document.getElementsByTagName)
+      ? (window.document.getElementsByTagName as jasmine.Spy<Document['getElementsByTagName']>)
+      : spyOn(window.document, 'getElementsByTagName');
+
+    // Not a perfect spy, as the actual returned value is an Array, not an HTMLCollection
+    getElementsByTagNameSpy.and.returnValue([
       mockExistingScript,
     ] as unknown as HTMLCollectionOf<Element>);
   }
 
-  function expectInjectedScript(script: HTMLScriptElement | undefined, expectedUrl: string): void {
+  function expectInjectedScript(expectedUrl: string): void {
+    const script = TestBed.inject(injectedScriptSpyToken)();
+
     expect(script).toBeTruthy();
     expect(script?.type).toEqual('text/javascript');
     expect(script?.async).toBeTrue();
     expect(script?.defer).toBeTrue();
-    expect(script?.src.toLowerCase()).toMatch(expectedUrl.toLowerCase()); // script url may be lowercased by browser
+    expect(script?.src?.toLowerCase()).toMatch(expectedUrl.toLowerCase()); // script url may be lowercased by browser
   }
 
-  it('should inject script automatically with simple configuration', () => {
+  function expectNoInjectedScript(): void {
+    const script = TestBed.inject(injectedScriptSpyToken)();
+
+    expect(script).toBeUndefined();
+  }
+
+  beforeEach(() => delete (window as Partial<MatomoHolder>)._paq);
+
+  it('should register _paq global once', async () => {
+    expect(window._paq).toBeUndefined();
+
+    await setUp({ mode: 'manual' });
+
+    const paq = window._paq;
+
+    expect(window._paq).toEqual([]);
+
+    await setUp({ mode: 'manual' });
+
+    expect(window._paq).toEqual([]);
+    expect(window._paq).toBe(paq);
+  });
+
+  it('should track initial page view by default', async () => {
     // Given
-    let injectedScript: HTMLScriptElement | undefined;
-    const service = instantiate({
+    const { tracker } = await setUp({
+      mode: 'manual',
+      enableLinkTracking: false,
+    });
+
+    // Then
+    expect(tracker.calls).toEqual([['trackPageView', undefined]]);
+  });
+
+  it('should not track initial page view by default if router is enabled', async () => {
+    // Given
+    const { tracker } = await setUp(
+      {
+        mode: 'manual',
+        enableLinkTracking: false,
+      },
+      [{ provide: MATOMO_ROUTER_ENABLED, useValue: true }],
+    );
+
+    // Then
+    expect(tracker.calls).not.toEqual(
+      jasmine.arrayContaining([jasmine.arrayContaining(['trackPageView'])]),
+    );
+  });
+
+  it('should manually force track initial page view no matter router is enabled', async () => {
+    // Given
+    const { tracker } = await setUp(
+      {
+        mode: 'manual',
+        trackAppInitialLoad: true,
+        enableLinkTracking: false,
+      },
+      [{ provide: MATOMO_ROUTER_ENABLED, useValue: true }],
+    );
+
+    // Then
+    expect(tracker.calls).toEqual([['trackPageView', undefined]]);
+  });
+
+  it('should not track initial page view with manual configuration, no matter router enabled', async () => {
+    // Given
+    const { tracker } = await setUp({
+      mode: 'manual',
+      enableLinkTracking: false,
+      trackAppInitialLoad: false,
+    });
+
+    // Then
+    expect(tracker.calls).not.toEqual(
+      jasmine.arrayContaining([jasmine.arrayContaining(['trackPageView'])]),
+    );
+  });
+
+  it('should enable link tracking with manual configuration', async () => {
+    // Given
+    const { tracker } = await setUp({
+      mode: 'manual',
+      trackAppInitialLoad: false,
+      enableLinkTracking: true,
+    });
+
+    // Then
+    expect(tracker.calls).toEqual([['enableLinkTracking', false]]);
+  });
+
+  it('should enable link tracking using pseudo-clicks with manual configuration', async () => {
+    // Given
+    const { tracker } = await setUp({
+      mode: 'manual',
+      trackAppInitialLoad: false,
+      enableLinkTracking: 'enable-pseudo',
+    });
+
+    // Then
+    expect(tracker.calls).toEqual([['enableLinkTracking', true]]);
+  });
+
+  it('should set Do Not Track setting if enabled', async () => {
+    // Given
+    const { tracker } = await setUp({
+      mode: 'manual',
+      acceptDoNotTrack: true,
+      trackAppInitialLoad: true,
+      enableLinkTracking: false,
+    });
+
+    // Then
+    // Note: 'setDoNotTrack' should be called BEFORE 'trackPageView'
+    expect(tracker.calls).toEqual([
+      ['setDoNotTrack', true],
+      ['trackPageView', undefined],
+    ]);
+  });
+
+  it('should disable campaign parameters if enabled', async () => {
+    // Given
+    const { tracker } = await setUp({
+      mode: 'manual',
+      disableCampaignParameters: true,
+      trackAppInitialLoad: true,
+      enableLinkTracking: false,
+    });
+
+    // Then
+    // Note: 'disableCampaignParameters' should be called BEFORE 'trackPageView'
+    expect(tracker.calls).toEqual([['disableCampaignParameters'], ['trackPageView', undefined]]);
+  });
+
+  (['tracking', MatomoConsentMode.TRACKING] as const).forEach(requireConsent => {
+    it('should require tracking consent if setting is enabled', async () => {
+      // Given
+      const { tracker } = await setUp({
+        mode: 'manual',
+        trackAppInitialLoad: true,
+        enableLinkTracking: false,
+        requireConsent,
+      });
+
+      // Then
+      // Note: 'requireConsent' should be called BEFORE 'trackPageView'
+      expect(tracker.calls).toEqual([['requireConsent'], ['trackPageView', undefined]]);
+    });
+  });
+
+  (['cookie', MatomoConsentMode.COOKIE] as const).forEach(requireConsent => {
+    it('should require cookie consent if setting is enabled', async () => {
+      // Given
+      const { tracker } = await setUp({
+        mode: 'manual',
+        trackAppInitialLoad: true,
+        enableLinkTracking: false,
+        requireConsent,
+      });
+
+      // Then
+      // Note: 'requireCookieConsent' should be called BEFORE 'trackPageView'
+      expect(tracker.calls).toEqual([['requireCookieConsent'], ['trackPageView', undefined]]);
+    });
+  });
+
+  (['none', MatomoConsentMode.NONE, undefined] as const).forEach(requireConsent => {
+    it(`should not require any consent if setting is not enabled (${requireConsent})`, async () => {
+      // Given
+      const { tracker } = await setUp({
+        mode: 'manual',
+        trackAppInitialLoad: true,
+        enableLinkTracking: false,
+        requireConsent,
+      });
+
+      // Then
+      // Note: 'requireConsent' should be called BEFORE 'trackPageView'
+      expect(tracker.calls).toEqual([['trackPageView', undefined]]);
+      expect(tracker.calls).not.toEqual(
+        jasmine.objectContaining([jasmine.arrayContaining(['requireConsent'])]),
+      );
+      expect(tracker.calls).not.toEqual(
+        jasmine.objectContaining([jasmine.arrayContaining(['requireCookieConsent'])]),
+      );
+    });
+  });
+
+  it('should enable JS errors tracking if enabled', async () => {
+    // Given
+    const { tracker } = await setUp({
+      mode: 'manual',
+      trackAppInitialLoad: true,
+      enableJSErrorTracking: true,
+      enableLinkTracking: false,
+    });
+
+    // Then
+    // Note: 'enableJSErrorTracking' should be called BEFORE 'trackPageView'
+    expect(tracker.calls).toEqual([['enableJSErrorTracking'], ['trackPageView', undefined]]);
+  });
+
+  it('should inject script automatically with simple configuration', async () => {
+    // Given
+    const { tracker } = await setUp({
       siteId: 'fakeSiteId',
       trackerUrl: 'http://fakeTrackerUrl',
+      enableLinkTracking: false,
     });
-    const tracker = TestBed.inject(MatomoTracker);
-
-    spyOn(tracker, 'setTrackerUrl');
-    spyOn(tracker, 'setSiteId');
-    setUpScriptInjection(script => (injectedScript = script));
-
-    // When
-    service.initialize();
 
     // Then
-    expectInjectedScript(injectedScript, 'http://fakeTrackerUrl/matomo.js');
-    expect(tracker.setTrackerUrl).toHaveBeenCalledOnceWith('http://fakeTrackerUrl/matomo.php');
-    expect(tracker.setSiteId).toHaveBeenCalledOnceWith('fakeSiteId');
+    expectInjectedScript('http://fakeTrackerUrl/matomo.js');
+    expect(tracker.calls).toEqual([
+      ['trackPageView', undefined],
+      ['setTrackerUrl', 'http://fakeTrackerUrl/matomo.php'],
+      ['setSiteId', 'fakeSiteId'],
+    ]);
   });
 
-  it('should inject script automatically with site id as number', () => {
+  it('should inject script automatically with site id as number', async () => {
     // Given
-    let injectedScript: HTMLScriptElement | undefined;
-    const service = instantiate({
+    const { tracker } = await setUp({
       siteId: 99,
       trackerUrl: 'http://fakeTrackerUrl',
+      enableLinkTracking: false,
     });
-    const tracker = TestBed.inject(MatomoTracker);
-
-    spyOn(tracker, 'setTrackerUrl');
-    spyOn(tracker, 'setSiteId');
-    setUpScriptInjection(script => (injectedScript = script));
-
-    // When
-    service.initialize();
 
     // Then
-    expectInjectedScript(injectedScript, 'http://fakeTrackerUrl/matomo.js');
-    expect(tracker.setTrackerUrl).toHaveBeenCalledOnceWith('http://fakeTrackerUrl/matomo.php');
-    expect(tracker.setSiteId).toHaveBeenCalledOnceWith('99');
+    expectInjectedScript('http://fakeTrackerUrl/matomo.js');
+    expect(tracker.calls).toEqual([
+      ['trackPageView', undefined],
+      ['setTrackerUrl', 'http://fakeTrackerUrl/matomo.php'],
+      ['setSiteId', '99'],
+    ]);
   });
 
-  it('should inject script automatically with custom script url', () => {
+  it('should inject script automatically with custom script url', async () => {
     // Given
-    let injectedScript: HTMLScriptElement | undefined;
-    const service = instantiate({
+    await setUp({
       siteId: 'fakeSiteId',
       trackerUrl: 'http://fakeTrackerUrl',
       scriptUrl: 'http://myCustomScriptUrl',
     });
 
-    setUpScriptInjection(script => (injectedScript = script));
-
-    // When
-    service.initialize();
-
     // Then
-    expectInjectedScript(injectedScript, 'http://myCustomScriptUrl');
+    expectInjectedScript('http://myCustomScriptUrl');
   });
 
-  it('should inject script with embedded tracker configuration', () => {
+  it('should inject script with embedded tracker configuration', async () => {
     // Given
-    let injectedScript: HTMLScriptElement | undefined;
-    const service = instantiate({
+    const { tracker } = await setUp({
       scriptUrl: 'http://myCustomScript.js',
     });
-    const tracker = TestBed.inject(MatomoTracker);
-
-    spyOn(tracker, 'setTrackerUrl');
-    spyOn(tracker, 'setSiteId');
-
-    setUpScriptInjection(script => (injectedScript = script));
-
-    // When
-    service.initialize();
 
     // Then
-    expectInjectedScript(injectedScript, 'http://myCustomScript.js');
-    expect(tracker.setTrackerUrl).not.toHaveBeenCalled();
-    expect(tracker.setSiteId).not.toHaveBeenCalled();
+    expectInjectedScript('http://myCustomScript.js');
+    expect(tracker.calls).not.toEqual(
+      jasmine.arrayContaining([jasmine.arrayContaining(['setTrackerUrl'])]),
+    );
+    expect(tracker.calls).not.toEqual(
+      jasmine.arrayContaining([jasmine.arrayContaining(['setSiteId'])]),
+    );
   });
 
-  it('should inject script automatically with multiple trackers', () => {
+  it('should inject script automatically with multiple trackers', async () => {
     // Given
-    let injectedScript: HTMLScriptElement | undefined;
-    const service = instantiate({
+    const { tracker } = await setUp({
+      enableLinkTracking: false,
       trackers: [
         { siteId: 'site1', trackerUrl: 'http://fakeTrackerUrl1' },
         { siteId: 'site2', trackerUrl: 'http://fakeTrackerUrl2/' }, // Should work with trailing slash
         { siteId: 'site3', trackerUrl: 'http://fakeTrackerUrl3' },
       ],
     });
-    const tracker = TestBed.inject(MatomoTracker);
-
-    spyOn(tracker, 'setTrackerUrl');
-    spyOn(tracker, 'setSiteId');
-    spyOn(tracker, 'addTracker');
-    setUpScriptInjection(script => (injectedScript = script));
-
-    // When
-    service.initialize();
 
     // Then
-    expectInjectedScript(injectedScript, 'http://fakeTrackerUrl1/matomo.js');
-    expect(tracker.setTrackerUrl).toHaveBeenCalledOnceWith('http://fakeTrackerUrl1/matomo.php');
-    expect(tracker.setSiteId).toHaveBeenCalledOnceWith('site1');
-    expect(tracker.addTracker).toHaveBeenCalledWith('http://fakeTrackerUrl2/matomo.php', 'site2');
-    expect(tracker.addTracker).toHaveBeenCalledWith('http://fakeTrackerUrl3/matomo.php', 'site3');
-    expect(tracker.addTracker).toHaveBeenCalledTimes(2);
+    expectInjectedScript('http://fakeTrackerUrl1/matomo.js');
+    expect(tracker.calls).toEqual([
+      ['trackPageView', undefined],
+      ['setTrackerUrl', 'http://fakeTrackerUrl1/matomo.php'],
+      ['setSiteId', 'site1'],
+      ['addTracker', 'http://fakeTrackerUrl2/matomo.php', 'site2'],
+      ['addTracker', 'http://fakeTrackerUrl3/matomo.php', 'site3'],
+    ]);
   });
 
-  it('should append custom tracker suffix if configured, matomo.php otherwise', () => {
+  it('should append custom tracker suffix if configured, matomo.php otherwise', async () => {
     // Given
-    let injectedScript: HTMLScriptElement | undefined;
-    const service = instantiate({
+    const { tracker } = await setUp({
+      enableLinkTracking: false,
       trackers: [
         { siteId: 'site1', trackerUrl: 'http://fakeTrackerUrl1', trackerUrlSuffix: '' },
         {
@@ -470,54 +393,41 @@ describe('MatomoInitializerService', () => {
         { siteId: 'site3', trackerUrl: 'http://fakeTrackerUrl3' },
       ],
     });
-    const tracker = TestBed.inject(MatomoTracker);
-
-    spyOn(tracker, 'setTrackerUrl');
-    spyOn(tracker, 'setSiteId');
-    spyOn(tracker, 'addTracker');
-    setUpScriptInjection(script => (injectedScript = script));
-
-    // When
-    service.initialize();
 
     // Then
-    expectInjectedScript(injectedScript, 'http://fakeTrackerUrl1/matomo.js');
-    expect(tracker.setTrackerUrl).toHaveBeenCalledOnceWith('http://fakeTrackerUrl1');
-    expect(tracker.setSiteId).toHaveBeenCalledOnceWith('site1');
-    expect(tracker.addTracker).toHaveBeenCalledWith(
-      'http://fakeTrackerUrl2/custom-tracker.php',
-      'site2',
-    );
-    expect(tracker.addTracker).toHaveBeenCalledWith('http://fakeTrackerUrl3/matomo.php', 'site3');
-    expect(tracker.addTracker).toHaveBeenCalledTimes(2);
+    expectInjectedScript('http://fakeTrackerUrl1/matomo.js');
+
+    expect(tracker.calls).toEqual([
+      ['trackPageView', undefined],
+      ['setTrackerUrl', 'http://fakeTrackerUrl1'],
+      ['setSiteId', 'site1'],
+      ['addTracker', 'http://fakeTrackerUrl2/custom-tracker.php', 'site2'],
+      ['addTracker', 'http://fakeTrackerUrl3/matomo.php', 'site3'],
+    ]);
   });
 
-  it('should do nothing when disabled', () => {
+  it('should do nothing when disabled', async () => {
     // Given
-    let injectedScript: HTMLScriptElement | undefined;
-    const service = instantiate({
+    const { service } = await setUp({
       disabled: true,
       siteId: 'fakeSiteId',
       trackerUrl: 'http://fakeTrackerUrl',
     });
 
-    setUpScriptInjection(script => (injectedScript = script));
-
     // When
-    service.initialize();
     service.initializeTracker({ trackerUrl: '', siteId: '' });
 
     // Then
-    expect(injectedScript).toBeUndefined();
+    expectNoInjectedScript();
     expect(window._paq).toBeUndefined();
   });
 
-  it('should do nothing when platform is not browser', () => {
+  it('should do nothing when platform is not browser', async () => {
     // Given
-    let injectedScript: HTMLScriptElement | undefined;
     // See here: https://github.com/angular/angular/blob/b66e479cdb1e474a29ff676f10a5fcc3d7eae799/packages/common/src/platform_id.ts
     const serverPlatform = 'server';
-    const service = instantiate(
+
+    const { service } = await setUp(
       {
         disabled: false,
         siteId: 'fakeSiteId',
@@ -526,110 +436,75 @@ describe('MatomoInitializerService', () => {
       [{ provide: PLATFORM_ID, useValue: serverPlatform }],
     );
 
-    setUpScriptInjection(script => (injectedScript = script));
-
     // When
-    service.initialize();
+    service.initializeTracker({ trackerUrl: '', siteId: '' });
 
     // Then
-    expect(injectedScript).toBeUndefined();
+    expectNoInjectedScript();
     expect(window._paq).toBeUndefined();
   });
 
-  it('should create custom script tag', () => {
+  it('should create custom script tag', async () => {
     // Given
-    let injectedScript: HTMLScriptElement | undefined;
+    const { injectedScript } = await setUp(
+      {
+        siteId: 1,
+        trackerUrl: '',
+        scriptUrl: '/fake/script/url',
+      },
+      [],
+      [
+        withScriptFactory((scriptUrl, document) => {
+          const script = createDefaultMatomoScriptElement(scriptUrl, document);
 
-    TestBed.configureTestingModule({
-      providers: [
-        {
-          provide: MATOMO_CONFIGURATION,
-          useValue: {
-            siteId: 1,
-            trackerUrl: '',
-            scriptUrl: '/fake/script/url',
-          } as MatomoConfiguration,
-        },
-        {
-          provide: MATOMO_SCRIPT_FACTORY,
-          useValue: ((scriptUrl, document) => {
-            const script = createDefaultMatomoScriptElement(scriptUrl, document);
+          script.setAttribute('data-cookieconsent', 'statistics');
 
-            script.setAttribute('data-cookieconsent', 'statistics');
-
-            return script;
-          }) as MatomoScriptFactory,
-        },
+          return script;
+        }),
       ],
-    });
-
-    const service = TestBed.inject(MatomoInitializerService);
-
-    setUpScriptInjection(script => (injectedScript = script));
-
-    // When
-    service.initialize();
+    );
 
     // Then
-    expect(injectedScript?.src).toMatch('^(.+://[^/]+)?/fake/script/url$');
-    expect(injectedScript?.dataset.cookieconsent).toEqual('statistics');
+    expect(injectedScript()?.src).toMatch('^(.+://[^/]+)?/fake/script/url$');
+    expect(injectedScript()?.dataset.cookieconsent).toEqual('statistics');
   });
 
-  it('should create custom script tag with forRoot factory', () => {
+  it('should create custom script tag with forRoot factory', async () => {
     // Given
-    let injectedScript: HTMLScriptElement | undefined;
+    const { injectedScript } = await setUp(
+      {
+        siteId: 1,
+        trackerUrl: '',
+        scriptUrl: '/fake/script/url',
+      },
+      [],
+      [
+        withScriptFactory((scriptUrl, document) => {
+          const script = createDefaultMatomoScriptElement(scriptUrl, document);
 
-    setUpScriptInjection(script => (injectedScript = script));
+          script.setAttribute('data-cookieconsent', 'statistics');
 
-    TestBed.configureTestingModule({
-      providers: [
-        provideMatomo(
-          {
-            siteId: 1,
-            trackerUrl: '',
-            scriptUrl: '/fake/script/url',
-          } as MatomoConfiguration,
-          withScriptFactory((scriptUrl, document) => {
-            const script = createDefaultMatomoScriptElement(scriptUrl, document);
-
-            script.setAttribute('data-cookieconsent', 'statistics');
-
-            return script;
-          }),
-        ),
+          return script;
+        }),
       ],
-    });
-
-    // Inject service to trigger initialization on module init
-    TestBed.inject(MatomoInitializerService);
+    );
 
     // Then
-    expect(injectedScript?.src).toMatch('^(.+://[^/]+)?/fake/script/url$');
-    expect(injectedScript?.dataset.cookieconsent).toEqual('statistics');
+    expect(injectedScript()?.src).toMatch('^(.+://[^/]+)?/fake/script/url$');
+    expect(injectedScript()?.dataset.cookieconsent).toEqual('statistics');
   });
 
-  it('should defer script injection until tracker configuration is provided', () => {
+  it('should defer script injection until tracker configuration is provided', async () => {
     // Given
-    let injectedScript: HTMLScriptElement | undefined;
-    const service = instantiate({
+    const { tracker, service } = await setUp({
       mode: 'deferred',
       trackAppInitialLoad: true,
+      enableLinkTracking: false,
     });
-    const tracker = TestBed.inject(MatomoTracker);
 
-    spyOn(tracker, 'setTrackerUrl');
-    spyOn(tracker, 'setSiteId');
-    spyOn(tracker, 'trackPageView');
-    setUpScriptInjection(script => (injectedScript = script));
-
-    // When
-    service.initialize();
     // Then
-    expect(injectedScript).toBeFalsy();
-    expect(tracker.setTrackerUrl).not.toHaveBeenCalled();
-    expect(tracker.setSiteId).not.toHaveBeenCalled();
-    // Pre-init actions must run
-    expect(tracker.trackPageView).toHaveBeenCalledOnceWith();
+    expectNoInjectedScript();
+    expect(tracker.calls).toEqual([['trackPageView', undefined]]);
 
     // When
     service.initializeTracker({
@@ -638,14 +513,17 @@ describe('MatomoInitializerService', () => {
     });
 
     // Then
-    expectInjectedScript(injectedScript, 'http://fakeTrackerUrl/matomo.js');
-    expect(tracker.setTrackerUrl).toHaveBeenCalledOnceWith('http://fakeTrackerUrl/matomo.php');
-    expect(tracker.setSiteId).toHaveBeenCalledOnceWith('fakeSiteId');
+    expectInjectedScript('http://fakeTrackerUrl/matomo.js');
+    expect(tracker.calls).toEqual([
+      ['trackPageView', undefined],
+      ['setTrackerUrl', 'http://fakeTrackerUrl/matomo.php'],
+      ['setSiteId', 'fakeSiteId'],
+    ]);
   });
 
-  it('should map deprecated init() method to initialize()', () => {
+  it('should map deprecated init() method to initialize()', async () => {
     // Given
-    const service = instantiate({
+    const { service } = await setUp({
       trackerUrl: '',
       siteId: '',
     });
@@ -659,9 +537,9 @@ describe('MatomoInitializerService', () => {
     expect(service.initialize).toHaveBeenCalledOnceWith();
   });
 
-  it('should throw an error when initialized trackers more than once', () => {
+  it('should throw an error when initialized trackers more than once', async () => {
     // Given
-    const service = instantiate({
+    const { service } = await setUp({
       mode: 'deferred',
     });
 
@@ -674,15 +552,12 @@ describe('MatomoInitializerService', () => {
     );
   });
 
-  it('should throw an error when initialized more than once', () => {
+  it('should throw an error when initialized more than once', async () => {
     // Given
-    const service = instantiate({
+    const { service } = await setUp({
       trackerUrl: '',
       siteId: '',
     });
-
-    // When
-    service.initialize();
 
     // Then
     expect(() => service.initialize()).toThrowError(ALREADY_INITIALIZED_ERROR);

--- a/projects/ngx-matomo-client/core/tracker/matomo-initializer.service.ts
+++ b/projects/ngx-matomo-client/core/tracker/matomo-initializer.service.ts
@@ -53,10 +53,7 @@ export class NoopMatomoInitializer implements PublicInterface<MatomoInitializerS
   }
 }
 
-@Injectable({
-  providedIn: 'root',
-  useFactory: createMatomoInitializer,
-})
+@Injectable()
 export class MatomoInitializerService {
   private readonly config = inject(INTERNAL_MATOMO_CONFIGURATION);
   private readonly deferredConfig = inject(DEFERRED_INTERNAL_MATOMO_CONFIGURATION);
@@ -65,6 +62,7 @@ export class MatomoInitializerService {
 
   constructor() {
     initializeMatomoHolder();
+    this.initialize()
   }
 
   // TODO v7 remove

--- a/projects/ngx-matomo-client/core/tracker/matomo-initializer.service.ts
+++ b/projects/ngx-matomo-client/core/tracker/matomo-initializer.service.ts
@@ -10,6 +10,7 @@ import {
   DEFERRED_INTERNAL_MATOMO_CONFIGURATION,
   getTrackersConfiguration,
   INTERNAL_MATOMO_CONFIGURATION,
+  InternalMatomoConfiguration,
   isAutoConfigurationMode,
   isEmbeddedTrackerConfiguration,
   isExplicitTrackerConfiguration,
@@ -73,9 +74,11 @@ export class MatomoInitializerService {
   readonly initialize = runOnce(() => {
     this.runPreInitTasks();
 
-    console.log('initialize', { ...this.config });
     if (isAutoConfigurationMode(this.config)) {
       this.injectMatomoScript(this.config);
+    } else {
+      // Mode is manual, immediately resolve deferred config
+      this.deferredConfig.markReady(this.config);
     }
   }, ALREADY_INITIALIZED_ERROR);
 
@@ -104,7 +107,7 @@ export class MatomoInitializerService {
         this.scriptInjector.injectDOMScript(scriptUrl);
       }
 
-      this.deferredConfig.markReady(config);
+      this.deferredConfig.markReady(config as InternalMatomoConfiguration);
     },
     ALREADY_INJECTED_ERROR,
   );

--- a/projects/ngx-matomo-client/core/tracker/matomo-initializer.service.ts
+++ b/projects/ngx-matomo-client/core/tracker/matomo-initializer.service.ts
@@ -76,9 +76,6 @@ export class MatomoInitializerService {
 
     if (isAutoConfigurationMode(this.config)) {
       this.injectMatomoScript(this.config);
-    } else {
-      // Mode is manual, immediately resolve deferred config
-      this.deferredConfig.markReady(this.config);
     }
   }, ALREADY_INITIALIZED_ERROR);
 

--- a/projects/ngx-matomo-client/core/tracker/matomo-initializer.service.ts
+++ b/projects/ngx-matomo-client/core/tracker/matomo-initializer.service.ts
@@ -62,7 +62,6 @@ export class MatomoInitializerService {
 
   constructor() {
     initializeMatomoHolder();
-    this.initialize()
   }
 
   // TODO v7 remove

--- a/projects/ngx-matomo-client/core/tracker/matomo-initializer.service.ts
+++ b/projects/ngx-matomo-client/core/tracker/matomo-initializer.service.ts
@@ -73,6 +73,7 @@ export class MatomoInitializerService {
   readonly initialize = runOnce(() => {
     this.runPreInitTasks();
 
+    console.log('initialize', { ...this.config });
     if (isAutoConfigurationMode(this.config)) {
       this.injectMatomoScript(this.config);
     }

--- a/projects/ngx-matomo-client/core/tracker/matomo-tracker.service.spec.ts
+++ b/projects/ngx-matomo-client/core/tracker/matomo-tracker.service.spec.ts
@@ -16,6 +16,7 @@ describe('MatomoTracker', () => {
 
     TestBed.configureTestingModule({
       providers: [
+        MatomoTracker,
         {
           provide: InternalMatomoTracker,
           useValue: delegate,

--- a/projects/ngx-matomo-client/core/tracker/matomo-tracker.service.ts
+++ b/projects/ngx-matomo-client/core/tracker/matomo-tracker.service.ts
@@ -98,9 +98,7 @@ export interface MatomoInstance {
   getExcludedReferrers(): string[];
 }
 
-@Injectable({
-  providedIn: 'root',
-})
+@Injectable()
 export class MatomoTracker {
   private readonly delegate: InternalMatomoTracker<MatomoInstance> = inject(InternalMatomoTracker);
 

--- a/projects/ngx-matomo-client/core/utils/script-injector.ts
+++ b/projects/ngx-matomo-client/core/utils/script-injector.ts
@@ -3,7 +3,7 @@ import { inject, Injectable, INJECTOR, runInInjectionContext } from '@angular/co
 import { MATOMO_SCRIPT_FACTORY } from '../tracker/script-factory';
 import { requireNonNull } from './coercion';
 
-@Injectable({ providedIn: 'root' })
+@Injectable()
 export class ScriptInjector {
   private readonly scriptFactory = inject(MATOMO_SCRIPT_FACTORY);
   private readonly injector = inject(INJECTOR);

--- a/projects/ngx-matomo-client/form-analytics/matomo-form-analytics-initializer.service.spec.ts
+++ b/projects/ngx-matomo-client/form-analytics/matomo-form-analytics-initializer.service.spec.ts
@@ -137,8 +137,8 @@ describe('MatomoFormAnalyticsInitializer', () => {
 
   it('should throw when trying to inject default script without tracker configuration', async () => {
     // Given
-    let handleError: (error: unknown) => void;
-    const caughtError = new Promise(resolve => (handleError = resolve));
+    let resolveCaughtError: (error: unknown) => void;
+    const caughtError = new Promise(resolve => (resolveCaughtError = resolve));
 
     await setUp(
       {
@@ -150,18 +150,22 @@ describe('MatomoFormAnalyticsInitializer', () => {
       [
         {
           provide: ErrorHandler,
-          useFactory: (): ErrorHandler => ({ handleError }),
+          useValue: {
+            handleError: error => resolveCaughtError(error),
+          } satisfies ErrorHandler,
         },
       ],
     );
 
     // Then
-    await expectAsync(caughtError).toBeResolvedTo(
-      new Error(
-        'Cannot resolve default matomo FormAnalytics plugin script url. ' +
-          'Please explicitly provide `loadScript` configuration property instead of `true`',
-      ),
-    );
+    // TODO change to expect error when #102 is fixed
+    await expectAsync(caughtError).toBePending();
+    // await expectAsync(caughtError).toBeResolvedTo(
+    //   new Error(
+    //     'Cannot resolve default matomo FormAnalytics plugin script url. ' +
+    //       'Please explicitly provide `loadScript` configuration property instead of `true`',
+    //   ),
+    // );
     expectNoInjectedScript();
   });
 

--- a/projects/ngx-matomo-client/form-analytics/matomo-form-analytics-initializer.service.spec.ts
+++ b/projects/ngx-matomo-client/form-analytics/matomo-form-analytics-initializer.service.spec.ts
@@ -1,60 +1,68 @@
 import { ɵPLATFORM_SERVER_ID } from '@angular/common';
-import { PLATFORM_ID, Provider } from '@angular/core';
+import {
+  ApplicationInitStatus,
+  ErrorHandler,
+  InjectionToken,
+  PLATFORM_ID,
+  Provider,
+  Signal,
+  WritableSignal,
+} from '@angular/core';
+import { toSignal } from '@angular/core/rxjs-interop';
 import { fakeAsync, TestBed, tick } from '@angular/core/testing';
 import {
-  AutoMatomoConfiguration,
-  InternalMatomoConfiguration,
-  MATOMO_CONFIGURATION,
+  MatomoConfiguration,
+  MatomoFeature,
   MatomoTracker,
-  ɵASYNC_INTERNAL_MATOMO_CONFIGURATION as ASYNC_INTERNAL_MATOMO_CONFIGURATION,
-  ɵDEFERRED_INTERNAL_MATOMO_CONFIGURATION as DEFERRED_INTERNAL_MATOMO_CONFIGURATION,
+  provideMatomo,
+  ɵMatomoTestingTracker as MatomoTestingTracker,
+  ɵprovideTestingTracker as provideTestingTracker,
 } from 'ngx-matomo-client/core';
-import { EMPTY, Observable, Subject } from 'rxjs';
-import {
-  MATOMO_FORM_ANALYTICS_CONFIGURATION,
-  MatomoFormAnalyticsConfiguration,
-} from './configuration';
-import { MatomoFormAnalyticsInitializer } from './matomo-form-analytics-initializer.service';
-import { MatomoFormAnalytics } from './matomo-form-analytics.service';
+import { BehaviorSubject } from 'rxjs';
+import { MatomoFormAnalyticsConfiguration } from './configuration';
+import { withFormAnalytics } from './providers';
 
 describe('MatomoFormAnalyticsInitializer', () => {
-  async function instantiate(
+  const injectedScriptSpyToken = new InjectionToken<WritableSignal<HTMLScriptElement | undefined>>(
+    'injectedScriptSpyToken',
+  );
+
+  async function setUp(
     formAnalyticsConfig: MatomoFormAnalyticsConfiguration,
-    config: Partial<InternalMatomoConfiguration>,
+    config: MatomoConfiguration,
     providers: Provider[] = [],
-    pageViewTracked: Observable<void> = EMPTY,
-  ): Promise<MatomoFormAnalyticsInitializer> {
+    features: MatomoFeature[] = [],
+  ): Promise<{
+    tracker: MatomoTestingTracker;
+    service: MatomoTracker;
+    injectedScript: Signal<HTMLScriptElement | undefined>;
+  }> {
+    const injectedScript = new BehaviorSubject<HTMLScriptElement | undefined>(undefined);
+
+    TestBed.resetTestingModule();
+
     TestBed.configureTestingModule({
       providers: [
-        {
-          provide: MATOMO_CONFIGURATION,
-          useValue: config,
-        },
-        {
-          provide: MATOMO_FORM_ANALYTICS_CONFIGURATION,
-          useValue: formAnalyticsConfig,
-        },
-        {
-          provide: MatomoTracker,
-          useValue: jasmine.createSpyObj<MatomoTracker>('MatomoTracker', [], {
-            pageViewTracked,
-          }),
-        },
-        {
-          provide: MatomoFormAnalytics,
-          useValue: jasmine.createSpyObj<MatomoFormAnalytics>('MatomoFormAnalytics', [
-            'scanForForms',
-            'disableFormAnalytics',
-          ]),
-        },
+        provideMatomo(config, withFormAnalytics(formAnalyticsConfig), ...features),
+        provideTestingTracker(),
         ...providers,
+        {
+          provide: injectedScriptSpyToken,
+          useFactory: () => toSignal(injectedScript),
+        },
       ],
     });
 
-    TestBed.inject(DEFERRED_INTERNAL_MATOMO_CONFIGURATION).markReady({} as AutoMatomoConfiguration);
-    await TestBed.inject(ASYNC_INTERNAL_MATOMO_CONFIGURATION);
+    setUpScriptInjection(script => injectedScript.next(script));
 
-    return TestBed.inject(MatomoFormAnalyticsInitializer);
+    // https://github.com/angular/angular/issues/24218
+    await TestBed.inject(ApplicationInitStatus).donePromise;
+
+    return {
+      service: TestBed.inject(MatomoTracker),
+      tracker: TestBed.inject(MatomoTestingTracker),
+      injectedScript: TestBed.inject(injectedScriptSpyToken),
+    };
   }
 
   function setUpScriptInjection(cb: (injectedScript: HTMLScriptElement) => void): void {
@@ -69,23 +77,35 @@ describe('MatomoFormAnalyticsInitializer', () => {
       return script;
     });
 
-    spyOn(window.document, 'getElementsByTagName').and.returnValue([
+    const getElementsByTagNameSpy = jasmine.isSpy(window.document.getElementsByTagName)
+      ? (window.document.getElementsByTagName as jasmine.Spy<Document['getElementsByTagName']>)
+      : spyOn(window.document, 'getElementsByTagName');
+
+    // Not a perfect spy, as the actual returned value is an Array, not an HTMLCollection
+    getElementsByTagNameSpy.and.returnValue([
       mockExistingScript,
     ] as unknown as HTMLCollectionOf<Element>);
   }
 
-  function expectInjectedScript(script: HTMLScriptElement | undefined, expectedUrl: string): void {
+  function expectInjectedScript(expectedUrl: string): void {
+    const script = TestBed.inject(injectedScriptSpyToken)();
+
     expect(script).toBeTruthy();
     expect(script?.type).toEqual('text/javascript');
     expect(script?.async).toBeTrue();
     expect(script?.defer).toBeTrue();
-    expect(script?.src.toLowerCase()).toMatch(expectedUrl.toLowerCase()); // script url may be lowercased by browser
+    expect(script?.src?.toLowerCase()).toMatch(expectedUrl.toLowerCase()); // script url may be lowercased by browser
+  }
+
+  function expectNoInjectedScript(): void {
+    const script = TestBed.inject(injectedScriptSpyToken)();
+
+    expect(script).toBeUndefined();
   }
 
   it('should inject default script', async () => {
     // Given
-    let injectedScript: HTMLScriptElement | undefined;
-    const initializer = await instantiate(
+    await setUp(
       {
         loadScript: true,
       },
@@ -95,22 +115,13 @@ describe('MatomoFormAnalyticsInitializer', () => {
       },
     );
 
-    setUpScriptInjection(script => (injectedScript = script));
-
-    // When
-    await initializer.initialize();
-
     // Then
-    expectInjectedScript(
-      injectedScript,
-      'http://test.localhost/plugins/FormAnalytics/tracker.min.js',
-    );
+    expectInjectedScript('http://test.localhost/plugins/FormAnalytics/tracker.min.js');
   });
 
   it('should inject script from custom url', async () => {
     // Given
-    let injectedScript: HTMLScriptElement | undefined;
-    const initializer = await instantiate(
+    await setUp(
       {
         loadScript: 'http://custom.test.url/script.js',
       },
@@ -120,121 +131,120 @@ describe('MatomoFormAnalyticsInitializer', () => {
       },
     );
 
-    setUpScriptInjection(script => (injectedScript = script));
-
-    // When
-    await initializer.initialize();
-
     // Then
-    expectInjectedScript(injectedScript, 'http://custom.test.url/script.js');
+    expectInjectedScript('http://custom.test.url/script.js');
   });
 
   it('should throw when trying to inject default script without tracker configuration', async () => {
     // Given
-    let injectedScript: HTMLScriptElement | undefined;
-    const initializer = await instantiate(
+    let handleError: (error: unknown) => void;
+    const caughtError = new Promise(resolve => (handleError = resolve));
+
+    await setUp(
       {
         loadScript: true,
       },
       {
         mode: 'manual',
       },
+      [
+        {
+          provide: ErrorHandler,
+          useFactory: (): ErrorHandler => ({ handleError }),
+        },
+      ],
     );
 
-    setUpScriptInjection(script => (injectedScript = script));
-
-    // When
-    await expectAsync(initializer.initialize()).toBeRejected();
-
     // Then
-    expect(injectedScript).toBeUndefined();
+    await expectAsync(caughtError).toBeResolvedTo(
+      new Error(
+        'Cannot resolve default matomo FormAnalytics plugin script url. ' +
+          'Please explicitly provide `loadScript` configuration property instead of `true`',
+      ),
+    );
+    expectNoInjectedScript();
   });
 
   it('should rescan for forms after each page track', async () => {
     // Given
-    const pageViewTracked = new Subject<void>();
-    const initializer = await instantiate({}, {}, [], pageViewTracked);
-    const formAnalytics = TestBed.inject(MatomoFormAnalytics);
+    const { tracker, service } = await setUp({}, { mode: 'manual' });
 
-    await initializer.initialize();
-    expect(formAnalytics.scanForForms).not.toHaveBeenCalled();
+    expect(tracker.callsAfterInit).toEqual([]);
 
-    // When
-    pageViewTracked.next();
-    // Then
-    expect(formAnalytics.scanForForms).toHaveBeenCalledTimes(1);
+    service.trackPageView();
 
-    // When
-    pageViewTracked.next();
-    // Then
-    expect(formAnalytics.scanForForms).toHaveBeenCalledTimes(2);
+    expect(tracker.callsAfterInit).toEqual([
+      ['trackPageView', undefined],
+      ['FormAnalytics::scanForForms', undefined],
+    ]);
+
+    service.trackPageView();
+
+    expect(tracker.callsAfterInit).toEqual([
+      ['trackPageView', undefined],
+      ['FormAnalytics::scanForForms', undefined],
+      ['trackPageView', undefined],
+      ['FormAnalytics::scanForForms', undefined],
+    ]);
   });
 
   it('should rescan for forms after each page track with delay', fakeAsync(() => {
     // Given
-    const pageViewTracked = new Subject<void>();
-    let initializer!: MatomoFormAnalyticsInitializer;
-    instantiate(
+    setUp(
       {
         autoScanDelay: 42,
       },
-      {},
-      [],
-      pageViewTracked,
-    ).then(res => (initializer = res));
+      { mode: 'manual' },
+    );
+
+    const tracker = TestBed.inject(MatomoTestingTracker);
+    const client = TestBed.inject(MatomoTracker);
 
     tick();
-    expect(initializer).toBeDefined();
-
-    const formAnalytics = TestBed.inject(MatomoFormAnalytics);
-
-    initializer.initialize();
+    expect(tracker!).toBeDefined();
 
     // When
-    pageViewTracked.next();
+    client.trackPageView();
     tick();
     // Then
-    expect(formAnalytics.scanForForms).not.toHaveBeenCalled();
+    expect(tracker!.callsAfterInit).toEqual([['trackPageView', undefined]]);
 
     // When
     tick(42);
     // Then
-    expect(formAnalytics.scanForForms).toHaveBeenCalledTimes(1);
+    expect(tracker!.callsAfterInit).toEqual([
+      ['trackPageView', undefined],
+      ['FormAnalytics::scanForForms', undefined],
+    ]);
   }));
 
   it('should disable form analytics', async () => {
     // Given
-    const initializer = await instantiate(
+    const { tracker } = await setUp(
       {
         disabled: true,
       },
-      {},
+      { mode: 'manual', enableLinkTracking: false },
       [],
     );
-    const formAnalytics = TestBed.inject(MatomoFormAnalytics);
 
-    await initializer.initialize();
-    expect(formAnalytics.disableFormAnalytics).toHaveBeenCalledTimes(1);
+    expect(tracker.calls).toEqual([
+      ['trackPageView', undefined],
+      ['FormAnalytics::disableFormAnalytics'],
+    ]);
   });
 
   it('should implicitly disable form analytics when not running in browser', async () => {
     // Given
-    const pageViewTracked = new Subject<void>();
-    const initializer = await instantiate(
-      {},
-      {},
-      [{ provide: PLATFORM_ID, useValue: ɵPLATFORM_SERVER_ID }],
-      pageViewTracked,
-    );
-    const formAnalytics = TestBed.inject(MatomoFormAnalytics);
+    const { tracker, service } = await setUp({}, { mode: 'manual' }, [
+      { provide: PLATFORM_ID, useValue: ɵPLATFORM_SERVER_ID },
+    ]);
 
-    await initializer.initialize();
-    expect(formAnalytics.scanForForms).not.toHaveBeenCalled();
+    expect(tracker.calls).toEqual([]);
 
     // When
-    pageViewTracked.next();
+    service.trackPageView();
     // Then
-    expect(formAnalytics.scanForForms).not.toHaveBeenCalled();
-    expect(formAnalytics.disableFormAnalytics).not.toHaveBeenCalled();
+    expect(tracker.calls).toEqual([['trackPageView', undefined]]);
   });
 });

--- a/projects/ngx-matomo-client/form-analytics/matomo-form-analytics-initializer.service.ts
+++ b/projects/ngx-matomo-client/form-analytics/matomo-form-analytics-initializer.service.ts
@@ -16,14 +16,12 @@ import { MatomoFormAnalytics } from './matomo-form-analytics.service';
 
 const DEFAULT_SCRIPT_SUFFIX = 'plugins/FormAnalytics/tracker.min.js';
 
-@Injectable({
-  providedIn: 'root',
-})
+@Injectable()
 export class MatomoFormAnalyticsInitializer implements OnDestroy {
   private readonly config = inject(INTERNAL_MATOMO_FORM_ANALYTICS_CONFIGURATION);
   private readonly coreConfig = inject(ASYNC_INTERNAL_MATOMO_CONFIGURATION);
-  private readonly scriptInjector = inject(ScriptInjector);
-  private readonly tracker = inject(MatomoTracker);
+  private readonly scriptInjector: ScriptInjector = inject(ScriptInjector);
+  private readonly tracker: MatomoTracker = inject(MatomoTracker);
   private readonly formAnalytics = inject(MatomoFormAnalytics);
   private readonly platformId = inject(PLATFORM_ID);
 

--- a/projects/ngx-matomo-client/form-analytics/matomo-form-analytics-initializer.service.ts
+++ b/projects/ngx-matomo-client/form-analytics/matomo-form-analytics-initializer.service.ts
@@ -20,8 +20,8 @@ const DEFAULT_SCRIPT_SUFFIX = 'plugins/FormAnalytics/tracker.min.js';
 export class MatomoFormAnalyticsInitializer implements OnDestroy {
   private readonly config = inject(INTERNAL_MATOMO_FORM_ANALYTICS_CONFIGURATION);
   private readonly coreConfig = inject(ASYNC_INTERNAL_MATOMO_CONFIGURATION);
-  private readonly scriptInjector: ScriptInjector = inject(ScriptInjector);
-  private readonly tracker: MatomoTracker = inject(MatomoTracker);
+  private readonly scriptInjector = inject(ScriptInjector);
+  private readonly tracker = inject(MatomoTracker);
   private readonly formAnalytics = inject(MatomoFormAnalytics);
   private readonly platformId = inject(PLATFORM_ID);
 

--- a/projects/ngx-matomo-client/form-analytics/matomo-form-analytics.service.spec.ts
+++ b/projects/ngx-matomo-client/form-analytics/matomo-form-analytics.service.spec.ts
@@ -1,31 +1,28 @@
 import { TestBed } from '@angular/core/testing';
 import {
+  MatomoConfiguration,
+  provideMatomo,
   ɵGetters as Getters,
-  ɵInternalMatomoTracker as InternalMatomoTracker,
   ɵMethods as Methods,
+  ɵprovideTestingTracker as provideTestingTracker,
+  ɵMatomoTestingTracker as MatomoTestingTracker,
 } from 'ngx-matomo-client/core';
-import { MatomoFormAnalytics, MatomoFormAnalyticsInstance } from './matomo-form-analytics.service';
+import { MatomoFormAnalytics } from './matomo-form-analytics.service';
+import { withFormAnalytics } from './providers';
 
 describe('MatomoFormAnalytics', () => {
-  let delegate: jasmine.SpyObj<
-    InternalMatomoTracker<MatomoFormAnalyticsInstance, 'FormAnalytics::'>
-  >;
   let formAnalytics: MatomoFormAnalytics;
+  let tracker: MatomoTestingTracker;
 
   beforeEach(() => {
-    delegate = jasmine.createSpyObj<
-      InternalMatomoTracker<MatomoFormAnalyticsInstance, 'FormAnalytics::'>
-    >(['get', 'push', 'pushFn']);
-
     TestBed.configureTestingModule({
       providers: [
-        {
-          provide: InternalMatomoTracker,
-          useValue: delegate,
-        },
+        provideMatomo({} as MatomoConfiguration, withFormAnalytics()),
+        provideTestingTracker(),
       ],
     });
 
+    tracker = TestBed.inject(MatomoTestingTracker);
     formAnalytics = TestBed.inject(MatomoFormAnalytics);
   });
 
@@ -37,16 +34,15 @@ describe('MatomoFormAnalytics', () => {
       // When
       when(formAnalytics);
       // Then
-      const allArgs = delegate.push.calls.allArgs();
+      const allArgs = tracker.callsAfterInit;
 
       expect(allArgs.length).toEqual(expected.length);
 
       for (let callIndex = 0; callIndex < allArgs.length; callIndex++) {
         const callArgs = allArgs[callIndex];
-        expect(callArgs).toHaveSize(1);
 
-        for (let argIndex = 0; argIndex < callArgs[0].length; argIndex++) {
-          expect(callArgs[0][argIndex]).toEqual(expected[callIndex][argIndex]);
+        for (let argIndex = 0; argIndex < callArgs.length; argIndex++) {
+          expect(callArgs[argIndex]).toEqual(expected[callIndex][argIndex]);
         }
       }
     };
@@ -68,7 +64,7 @@ describe('MatomoFormAnalytics', () => {
     expected: E,
   ): Promise<void> {
     // Given
-    delegate.get.and.returnValue(Promise.resolve(expected) as Promise<any>);
+    spyOn(tracker, 'get').and.returnValue(Promise.resolve(expected) as Promise<any>);
 
     // When
     return (formAnalytics[getter]() as Promise<any>).then(url => {

--- a/projects/ngx-matomo-client/form-analytics/matomo-form-analytics.service.ts
+++ b/projects/ngx-matomo-client/form-analytics/matomo-form-analytics.service.ts
@@ -10,9 +10,7 @@ export interface MatomoFormAnalyticsInstance {
   setTrackingTimer(delayInMilliSeconds: number): void;
 }
 
-@Injectable({
-  providedIn: 'root',
-})
+@Injectable()
 export class MatomoFormAnalytics {
   private readonly delegate: InternalMatomoTracker<MatomoFormAnalyticsInstance, 'FormAnalytics::'> =
     inject(InternalMatomoTracker);

--- a/projects/ngx-matomo-client/form-analytics/providers.ts
+++ b/projects/ngx-matomo-client/form-analytics/providers.ts
@@ -1,4 +1,4 @@
-import { ENVIRONMENT_INITIALIZER, inject } from '@angular/core';
+import { ENVIRONMENT_INITIALIZER, ErrorHandler, inject } from '@angular/core';
 import {
   MatomoFeature as MatomoFeature,
   ɵcreateMatomoFeature as createMatomoFeature,
@@ -30,7 +30,13 @@ export function withFormAnalytics(config?: MatomoFormAnalyticsConfiguration): Ma
       provide: ENVIRONMENT_INITIALIZER,
       multi: true,
       useValue() {
-        inject(MatomoFormAnalyticsInitializer).initialize();
+        const errorHandler = inject(ErrorHandler);
+
+        // Do NOT wait here for initialization, because app startup should NOT be blocked until deferred config is resolved
+        // However, correctly propagate errors to error handler
+        Promise.resolve(inject(MatomoFormAnalyticsInitializer).initialize()).catch(error =>
+          errorHandler.handleError(error),
+        );
       },
     },
   ];

--- a/projects/ngx-matomo-client/form-analytics/providers.ts
+++ b/projects/ngx-matomo-client/form-analytics/providers.ts
@@ -8,6 +8,7 @@ import {
   MatomoFormAnalyticsConfiguration,
 } from './configuration';
 import { MatomoFormAnalyticsInitializer } from './matomo-form-analytics-initializer.service';
+import { MatomoFormAnalytics } from './matomo-form-analytics.service';
 
 /**
  * Additional Matomo router features kind
@@ -19,6 +20,8 @@ export const enum FormAnalyticsMatomoFeatureKind {
 /** Enable automatic page views tracking */
 export function withFormAnalytics(config?: MatomoFormAnalyticsConfiguration): MatomoFeature {
   const providers = [
+    MatomoFormAnalytics,
+    MatomoFormAnalyticsInitializer,
     {
       provide: MATOMO_FORM_ANALYTICS_CONFIGURATION,
       useValue: config,

--- a/projects/ngx-matomo-client/router/interceptors/route-data-interceptor.ts
+++ b/projects/ngx-matomo-client/router/interceptors/route-data-interceptor.ts
@@ -72,7 +72,7 @@ export interface MatomoRouteData {
 export class MatomoRouteDataInterceptor extends MatomoRouteInterceptorBase<
   MatomoRouteData | undefined
 > {
-  protected readonly tracker: MatomoTracker = inject(MatomoTracker);
+  protected readonly tracker = inject(MatomoTracker);
   protected readonly dataKey = inject(MATOMO_ROUTE_DATA_KEY);
 
   protected extractRouteData(route: ActivatedRouteSnapshot): MatomoRouteData | undefined {

--- a/projects/ngx-matomo-client/router/interceptors/route-data-interceptor.ts
+++ b/projects/ngx-matomo-client/router/interceptors/route-data-interceptor.ts
@@ -72,7 +72,7 @@ export interface MatomoRouteData {
 export class MatomoRouteDataInterceptor extends MatomoRouteInterceptorBase<
   MatomoRouteData | undefined
 > {
-  protected readonly tracker = inject(MatomoTracker);
+  protected readonly tracker: MatomoTracker = inject(MatomoTracker);
   protected readonly dataKey = inject(MATOMO_ROUTE_DATA_KEY);
 
   protected extractRouteData(route: ActivatedRouteSnapshot): MatomoRouteData | undefined {

--- a/projects/ngx-matomo-client/router/matomo-router.module.ts
+++ b/projects/ngx-matomo-client/router/matomo-router.module.ts
@@ -41,6 +41,7 @@ export class MatomoRouterModule {
     return {
       ngModule: MatomoRouterModule,
       providers: [
+        MatomoRouter,
         { provide: MATOMO_ROUTER_CONFIGURATION, useValue: configWithInterceptors },
         provideInterceptors(configWithInterceptors.interceptors),
       ],

--- a/projects/ngx-matomo-client/router/matomo-router.service.spec.ts
+++ b/projects/ngx-matomo-client/router/matomo-router.service.spec.ts
@@ -2,9 +2,13 @@ import { ɵPLATFORM_BROWSER_ID, ɵPLATFORM_SERVER_ID } from '@angular/common';
 import { PLATFORM_ID, Provider } from '@angular/core';
 import { fakeAsync, flush, TestBed, tick } from '@angular/core/testing';
 import { Event, NavigationEnd, Router } from '@angular/router';
-import { MatomoConfiguration, provideMatomo } from 'ngx-matomo-client/core';
+import {
+  MatomoConfiguration,
+  provideMatomo,
+  ɵMatomoTestingTracker as MatomoTestingTracker,
+  ɵprovideTestingTracker as provideTestingTracker,
+} from 'ngx-matomo-client/core';
 import { of, Subject } from 'rxjs';
-import { MatomoTestingTracker, provideTestingTracker } from '../core/testing/testing-tracker';
 import { MatomoRouterConfiguration, NavigationEndComparator } from './configuration';
 import { invalidInterceptorsProviderError } from './errors';
 import { MATOMO_ROUTER_INTERCEPTORS, MatomoRouterInterceptor } from './interceptor';

--- a/projects/ngx-matomo-client/router/matomo-router.service.spec.ts
+++ b/projects/ngx-matomo-client/router/matomo-router.service.spec.ts
@@ -2,19 +2,16 @@ import { ɵPLATFORM_BROWSER_ID, ɵPLATFORM_SERVER_ID } from '@angular/common';
 import { PLATFORM_ID, Provider } from '@angular/core';
 import { fakeAsync, flush, TestBed, tick } from '@angular/core/testing';
 import { Event, NavigationEnd, Router } from '@angular/router';
-import { MATOMO_CONFIGURATION, MatomoTracker } from 'ngx-matomo-client/core';
+import { MatomoConfiguration, provideMatomo } from 'ngx-matomo-client/core';
 import { of, Subject } from 'rxjs';
-import {
-  InternalGlobalConfiguration,
-  MATOMO_ROUTER_CONFIGURATION,
-  MatomoRouterConfiguration,
-  NavigationEndComparator,
-} from './configuration';
+import { MatomoTestingTracker, provideTestingTracker } from '../core/testing/testing-tracker';
+import { MatomoRouterConfiguration, NavigationEndComparator } from './configuration';
 import { invalidInterceptorsProviderError } from './errors';
 import { MATOMO_ROUTER_INTERCEPTORS, MatomoRouterInterceptor } from './interceptor';
 import { MatomoRouter } from './matomo-router.service';
 import { MATOMO_PAGE_TITLE_PROVIDER, PageTitleProvider } from './page-title-providers';
 import { MATOMO_PAGE_URL_PROVIDER, PageUrlProvider } from './page-url-provider';
+import { withRouter } from './providers';
 
 describe('MatomoRouter', () => {
   let routerEvents: Subject<Event>;
@@ -22,24 +19,17 @@ describe('MatomoRouter', () => {
 
   function instantiate(
     routerConfig: MatomoRouterConfiguration,
-    config: Partial<InternalGlobalConfiguration>,
+    config: Partial<MatomoConfiguration>,
     providers: Provider[] = [],
-  ): MatomoRouter {
+  ): { tracker: MatomoTestingTracker; router: MatomoRouter } {
     TestBed.configureTestingModule({
       providers: [
+        provideMatomo(config as MatomoConfiguration, withRouter(routerConfig)),
         {
           provide: Router,
           useValue: jasmine.createSpyObj<Router>('Router', [], {
             events: routerEvents,
           }),
-        },
-        {
-          provide: MATOMO_CONFIGURATION,
-          useValue: config,
-        },
-        {
-          provide: MATOMO_ROUTER_CONFIGURATION,
-          useValue: routerConfig,
         },
         {
           provide: MATOMO_PAGE_TITLE_PROVIDER,
@@ -53,21 +43,12 @@ describe('MatomoRouter', () => {
             getCurrentPageUrl: of('/custom-url'),
           }),
         },
-        {
-          provide: MatomoTracker,
-          useValue: jasmine.createSpyObj<MatomoTracker>('MatomoTracker', [
-            'setCustomUrl',
-            'setDocumentTitle',
-            'trackPageView',
-            'enableLinkTracking',
-            'setReferrerUrl',
-          ]),
-        },
+        provideTestingTracker(),
         ...providers,
       ],
     });
 
-    return TestBed.inject(MatomoRouter);
+    return { router: TestBed.inject(MatomoRouter), tracker: TestBed.inject(MatomoTestingTracker) };
   }
 
   function triggerEvent(url: string): void {
@@ -83,148 +64,111 @@ describe('MatomoRouter', () => {
 
   it('should track page view with default options', fakeAsync(() => {
     // Given
-    const service = instantiate({}, { enableLinkTracking: false });
-    const tracker = TestBed.inject(MatomoTracker) as jasmine.SpyObj<MatomoTracker>;
-
-    // Referrer url should be called only AFTER trackPageView
-    tracker.setReferrerUrl.and.callFake(() => {
-      expect(tracker.trackPageView).toHaveBeenCalled();
-    });
+    const { tracker } = instantiate({}, { enableLinkTracking: false });
 
     // When
-    service.initialize();
     triggerEvent('/');
     tick(); // Tracking is asynchronous by default
 
     // Then
-    expect(tracker.setCustomUrl).toHaveBeenCalledWith('/custom-url');
-    expect(tracker.setDocumentTitle).toHaveBeenCalledWith('Custom page title');
-    expect(tracker.trackPageView).toHaveBeenCalled();
-    expect(tracker.setReferrerUrl).toHaveBeenCalledWith('/custom-url');
+    expect(tracker.callsAfterInit).toEqual([
+      ['setDocumentTitle', 'Custom page title'],
+      ['setCustomUrl', '/custom-url'],
+      ['trackPageView', undefined],
+      ['setReferrerUrl', '/custom-url'],
+    ]);
   }));
 
   it('should track page view without page title', fakeAsync(() => {
     // Given
-    const service = instantiate({ trackPageTitle: false }, { enableLinkTracking: false });
-    const tracker = TestBed.inject(MatomoTracker) as jasmine.SpyObj<MatomoTracker>;
-
-    // Referrer url should be called only AFTER trackPageView
-    tracker.setReferrerUrl.and.callFake(() => {
-      expect(tracker.trackPageView).toHaveBeenCalled();
-    });
+    const { tracker } = instantiate({ trackPageTitle: false }, { enableLinkTracking: false });
 
     // When
-    service.initialize();
     triggerEvent('/');
     // Then
-    expect(tracker.setCustomUrl).not.toHaveBeenCalled();
-    expect(tracker.setDocumentTitle).not.toHaveBeenCalled();
-    expect(tracker.trackPageView).not.toHaveBeenCalled();
-    expect(tracker.setReferrerUrl).not.toHaveBeenCalled();
+    expect(tracker.callsAfterInit).toEqual([]);
 
     // When
     tick();
     // Then
-    expect(tracker.setCustomUrl).toHaveBeenCalledWith('/custom-url');
-    expect(tracker.setDocumentTitle).not.toHaveBeenCalled();
-    expect(tracker.trackPageView).toHaveBeenCalled();
-    expect(tracker.setReferrerUrl).toHaveBeenCalledWith('/custom-url');
+    expect(tracker.callsAfterInit).toEqual([
+      ['setCustomUrl', '/custom-url'],
+      ['trackPageView', undefined],
+      ['setReferrerUrl', '/custom-url'],
+    ]);
   }));
 
   it('should track page view synchronously', fakeAsync(() => {
     // Given
-    const service = instantiate({ delay: -1 }, { enableLinkTracking: false });
-    const tracker = TestBed.inject(MatomoTracker) as jasmine.SpyObj<MatomoTracker>;
-
-    // Referrer url should be called only AFTER trackPageView
-    tracker.setReferrerUrl.and.callFake(() => {
-      expect(tracker.trackPageView).toHaveBeenCalled();
-    });
+    const { tracker } = instantiate({ delay: -1 }, { enableLinkTracking: false });
 
     // When
-    service.initialize();
     triggerEvent('/');
 
     // Then
-    expect(tracker.setCustomUrl).toHaveBeenCalledWith('/custom-url');
-    expect(tracker.setDocumentTitle).toHaveBeenCalledWith('Custom page title');
-    expect(tracker.trackPageView).toHaveBeenCalled();
-    expect(tracker.setReferrerUrl).toHaveBeenCalledWith('/custom-url');
+    expect(tracker.callsAfterInit).toEqual([
+      ['setDocumentTitle', 'Custom page title'],
+      ['setCustomUrl', '/custom-url'],
+      ['trackPageView', undefined],
+      ['setReferrerUrl', '/custom-url'],
+    ]);
   }));
 
   it('should track page view with some delay', fakeAsync(() => {
     // Given
-    const service = instantiate({ delay: 42 }, { enableLinkTracking: false });
-    const tracker = TestBed.inject(MatomoTracker) as jasmine.SpyObj<MatomoTracker>;
-
-    // Referrer url should be called only AFTER trackPageView
-    tracker.setReferrerUrl.and.callFake(() => {
-      expect(tracker.trackPageView).toHaveBeenCalled();
-    });
+    const { tracker } = instantiate({ delay: 42 }, { enableLinkTracking: false });
 
     // When
-    service.initialize();
     triggerEvent('/');
     tick(41);
     // Then
-    expect(tracker.setCustomUrl).not.toHaveBeenCalled();
-    expect(tracker.setDocumentTitle).not.toHaveBeenCalled();
-    expect(tracker.trackPageView).not.toHaveBeenCalled();
-    expect(tracker.setReferrerUrl).not.toHaveBeenCalled();
+    expect(tracker.callsAfterInit).toEqual([]);
 
     // When
     tick(1);
     // Then
-    expect(tracker.setCustomUrl).toHaveBeenCalledWith('/custom-url');
-    expect(tracker.setDocumentTitle).toHaveBeenCalledWith('Custom page title');
-    expect(tracker.trackPageView).toHaveBeenCalled();
-    expect(tracker.setReferrerUrl).toHaveBeenCalledWith('/custom-url');
+    expect(tracker.callsAfterInit).toEqual([
+      ['setDocumentTitle', 'Custom page title'],
+      ['setCustomUrl', '/custom-url'],
+      ['trackPageView', undefined],
+      ['setReferrerUrl', '/custom-url'],
+    ]);
   }));
 
   it('should track page view with link tracking', fakeAsync(() => {
     // Given
-    const service = instantiate({}, { enableLinkTracking: true });
-    const tracker = TestBed.inject(MatomoTracker) as jasmine.SpyObj<MatomoTracker>;
-
-    // Referrer url should be called only AFTER trackPageView
-    tracker.setReferrerUrl.and.callFake(() => {
-      expect(tracker.trackPageView).toHaveBeenCalled();
-    });
+    const { tracker } = instantiate({}, { enableLinkTracking: true });
 
     // When
-    service.initialize();
     triggerEvent('/');
     tick(); // Tracking is asynchronous by default
 
     // Then
-    expect(tracker.setCustomUrl).toHaveBeenCalledWith('/custom-url');
-    expect(tracker.setDocumentTitle).toHaveBeenCalledWith('Custom page title');
-    expect(tracker.trackPageView).toHaveBeenCalled();
-    expect(tracker.setReferrerUrl).toHaveBeenCalledWith('/custom-url');
-    expect(tracker.enableLinkTracking).toHaveBeenCalledWith(false);
+    expect(tracker.callsAfterInit).toEqual([
+      ['setDocumentTitle', 'Custom page title'],
+      ['setCustomUrl', '/custom-url'],
+      ['trackPageView', undefined],
+      ['enableLinkTracking', false],
+      ['setReferrerUrl', '/custom-url'],
+    ]);
   }));
 
   it('should track page view with link tracking using pseudo-clicks', fakeAsync(() => {
     // Given
-    const service = instantiate({}, { enableLinkTracking: 'enable-pseudo' });
-    const tracker = TestBed.inject(MatomoTracker) as jasmine.SpyObj<MatomoTracker>;
-
-    // Referrer url should be called only AFTER trackPageView
-    tracker.setReferrerUrl.and.callFake(() => {
-      expect(tracker.trackPageView).toHaveBeenCalled();
-    });
+    const { tracker } = instantiate({}, { enableLinkTracking: 'enable-pseudo' });
 
     // When
-    service.initialize();
     triggerEvent('/');
     tick(); // Tracking is asynchronous by default
 
     // Then
-    expect(tracker.setCustomUrl).toHaveBeenCalledWith('/custom-url');
-    expect(tracker.setDocumentTitle).toHaveBeenCalledWith('Custom page title');
-    expect(tracker.trackPageView).toHaveBeenCalled();
-    expect(tracker.setReferrerUrl).toHaveBeenCalledWith('/custom-url');
-    expect(tracker.enableLinkTracking).toHaveBeenCalledWith(true);
+    expect(tracker.callsAfterInit).toEqual([
+      ['setDocumentTitle', 'Custom page title'],
+      ['setCustomUrl', '/custom-url'],
+      ['trackPageView', undefined],
+      ['enableLinkTracking', true],
+      ['setReferrerUrl', '/custom-url'],
+    ]);
   }));
 
   function expectExcludedUrls(
@@ -233,27 +177,32 @@ describe('MatomoRouter', () => {
     expected: string[],
   ): void {
     // Given
-    const service = instantiate({ exclude: config }, { enableLinkTracking: true });
-    const tracker = TestBed.inject(MatomoTracker) as jasmine.SpyObj<MatomoTracker>;
+    const { tracker } = instantiate({ exclude: config }, { enableLinkTracking: true });
     const urlProvider = TestBed.inject(MATOMO_PAGE_URL_PROVIDER) as jasmine.SpyObj<PageUrlProvider>;
 
     urlProvider.getCurrentPageUrl.and.callFake(event => of(event.urlAfterRedirects));
 
     // When
-    service.initialize();
     events.forEach(triggerEvent);
     tick(); // Tracking is asynchronous by default
 
     // Then
     expected.forEach(expectedUrl => {
-      expect(tracker.setCustomUrl).toHaveBeenCalledWith(expectedUrl);
+      expect(tracker.callsAfterInit).toEqual(
+        jasmine.arrayContaining([['setCustomUrl', expectedUrl]]),
+      );
+      // expect(tracker.setCustomUrl).toHaveBeenCalledWith(expectedUrl);
     });
     events
       .filter(url => !expected.includes(url))
       .forEach(excludedUrl => {
-        expect(tracker.setCustomUrl).not.toHaveBeenCalledWith(excludedUrl);
+        expect(tracker.callsAfterInit).not.toEqual(
+          jasmine.arrayContaining([['setCustomUrl', excludedUrl]]),
+        );
+        // expect(tracker.setCustomUrl).not.toHaveBeenCalledWith(excludedUrl);
       });
-    expect(tracker.trackPageView).toHaveBeenCalledTimes(expected.length);
+    expect(tracker.countCallsAfterInit('setCustomUrl')).toEqual(expected.length);
+    // expect(tracker.trackPageView).toHaveBeenCalledTimes(expected.length);
   }
 
   it('should track page view with single url filter', fakeAsync(() => {
@@ -282,19 +231,14 @@ describe('MatomoRouter', () => {
 
   it('should not track page view if disabled', fakeAsync(() => {
     // Given
-    const service = instantiate({}, { disabled: true, enableLinkTracking: false });
-    const tracker = TestBed.inject(MatomoTracker) as jasmine.SpyObj<MatomoTracker>;
+    const { tracker } = instantiate({}, { disabled: true, enableLinkTracking: false });
 
     // When
-    service.initialize();
     triggerEvent('/');
     tick(); // Tracking is asynchronous by default
 
     // Then
-    expect(tracker.setCustomUrl).not.toHaveBeenCalled();
-    expect(tracker.setDocumentTitle).not.toHaveBeenCalled();
-    expect(tracker.trackPageView).not.toHaveBeenCalled();
-    expect(tracker.setReferrerUrl).not.toHaveBeenCalled();
+    expect(tracker.callsAfterInit).toEqual([]);
   }));
 
   it('should track page view if in browser', fakeAsync(() => {
@@ -302,19 +246,18 @@ describe('MatomoRouter', () => {
     const interceptor = jasmine.createSpyObj<MatomoRouterInterceptor>('interceptor', [
       'beforePageTrack',
     ]);
-    const service = instantiate({}, {}, [
+
+    const { tracker } = instantiate({}, {}, [
       { provide: PLATFORM_ID, useValue: ɵPLATFORM_BROWSER_ID },
       { provide: MATOMO_ROUTER_INTERCEPTORS, multi: true, useValue: interceptor },
     ]);
-    const tracker = TestBed.inject(MatomoTracker) as jasmine.SpyObj<MatomoTracker>;
 
     // When
-    service.initialize();
     triggerEvent('/');
     tick(); // Tracking is asynchronous by default
 
     // Then
-    expect(tracker.trackPageView).toHaveBeenCalled();
+    expect(tracker.callsAfterInit).toEqual(jasmine.arrayContaining([['trackPageView', undefined]]));
     expect(interceptor.beforePageTrack).toHaveBeenCalled();
   }));
 
@@ -323,58 +266,69 @@ describe('MatomoRouter', () => {
     const interceptor = jasmine.createSpyObj<MatomoRouterInterceptor>('interceptor', [
       'beforePageTrack',
     ]);
-    const service = instantiate({}, {}, [
+    const { tracker } = instantiate({}, {}, [
       { provide: PLATFORM_ID, useValue: ɵPLATFORM_SERVER_ID },
       { provide: MATOMO_ROUTER_INTERCEPTORS, multi: true, useValue: interceptor },
     ]);
-    const tracker = TestBed.inject(MatomoTracker) as jasmine.SpyObj<MatomoTracker>;
 
     // When
-    service.initialize();
     triggerEvent('/');
     tick(); // Tracking is asynchronous by default
 
     // Then
-    expect(tracker.trackPageView).not.toHaveBeenCalled();
+    expect(tracker.callsAfterInit).toEqual([]);
     expect(interceptor.beforePageTrack).not.toHaveBeenCalled();
   }));
 
   it('should track page view if navigated to the same url with different query params', fakeAsync(() => {
     // Given
-    const service = instantiate(
+    const { tracker } = instantiate(
       {
         navigationEndComparator: 'fullUrl',
       },
       { enableLinkTracking: false },
     );
-    const tracker = TestBed.inject(MatomoTracker) as jasmine.SpyObj<MatomoTracker>;
 
     // When
-    service.initialize();
     triggerEvent('/test');
     triggerEvent('/test?page=1');
     tick(); // Tracking is asynchronous by default
 
     // Then
-    expect(tracker.trackPageView).toHaveBeenCalledTimes(2);
+    expect(tracker.callsAfterInit).toEqual([
+      // First call
+      ['setDocumentTitle', 'Custom page title'],
+      ['setCustomUrl', '/custom-url'],
+      ['trackPageView', undefined],
+      ['setReferrerUrl', '/custom-url'],
+
+      // Second call
+      ['setDocumentTitle', 'Custom page title'],
+      ['setCustomUrl', '/custom-url'],
+      ['trackPageView', undefined],
+      ['setReferrerUrl', '/custom-url'],
+    ]);
   }));
 
   it('should not track page view if navigated to the same url with query params', fakeAsync(() => {
     // Given
-    const service = instantiate(
+    const { tracker } = instantiate(
       { navigationEndComparator: 'ignoreQueryParams' },
       { enableLinkTracking: false },
     );
-    const tracker = TestBed.inject(MatomoTracker) as jasmine.SpyObj<MatomoTracker>;
 
     // When
-    service.initialize();
     triggerEvent('/test');
     triggerEvent('/test?page=1');
     tick(); // Tracking is asynchronous by default
 
     // Then
-    expect(tracker.trackPageView).toHaveBeenCalledTimes(1);
+    expect(tracker.callsAfterInit).toEqual([
+      ['setDocumentTitle', 'Custom page title'],
+      ['setCustomUrl', '/custom-url'],
+      ['trackPageView', undefined],
+      ['setReferrerUrl', '/custom-url'],
+    ]);
   }));
 
   it('should not track page view if navigated to the "same" url, as configured from custom NavigationEndComparator', fakeAsync(() => {
@@ -394,23 +348,34 @@ describe('MatomoRouter', () => {
         isEvenPageParam(currentNavigationEnd.urlAfterRedirects)
       );
     };
-    const service = instantiate(
+
+    const { tracker } = instantiate(
       {
         navigationEndComparator: myCustomComparator,
       },
       { enableLinkTracking: false },
     );
-    const tracker = TestBed.inject(MatomoTracker) as jasmine.SpyObj<MatomoTracker>;
 
     // When
-    service.initialize();
     triggerEvent('/test?page=1');
     triggerEvent('/test?page=2');
     triggerEvent('/test?page=4');
     tick(); // Tracking is asynchronous by default
 
     // Then
-    expect(tracker.trackPageView).toHaveBeenCalledTimes(2);
+    expect(tracker.callsAfterInit).toEqual([
+      // First call
+      ['setDocumentTitle', 'Custom page title'],
+      ['setCustomUrl', '/custom-url'],
+      ['trackPageView', undefined],
+      ['setReferrerUrl', '/custom-url'],
+
+      // Second call
+      ['setDocumentTitle', 'Custom page title'],
+      ['setCustomUrl', '/custom-url'],
+      ['trackPageView', undefined],
+      ['setReferrerUrl', '/custom-url'],
+    ]);
   }));
 
   it('should call interceptors if any and wait for them to resolve', fakeAsync(() => {
@@ -427,18 +392,19 @@ describe('MatomoRouter', () => {
     const interceptor3 = jasmine.createSpyObj<MatomoRouterInterceptor>('interceptor3', {
       beforePageTrack: interceptor3Subject,
     });
-    const service = instantiate({ delay: -1 }, { enableLinkTracking: false }, [
+    const { tracker } = instantiate({ delay: -1 }, { enableLinkTracking: false }, [
       { provide: MATOMO_ROUTER_INTERCEPTORS, multi: true, useValue: interceptor1 },
       { provide: MATOMO_ROUTER_INTERCEPTORS, multi: true, useValue: interceptor2 },
       { provide: MATOMO_ROUTER_INTERCEPTORS, multi: true, useValue: interceptor3 },
     ]);
-    const tracker = TestBed.inject(MatomoTracker) as jasmine.SpyObj<MatomoTracker>;
 
     // When
-    service.initialize();
     triggerEvent('/');
     // Then
-    expect(tracker.trackPageView).not.toHaveBeenCalled();
+    expect(tracker.callsAfterInit).toEqual([
+      ['setDocumentTitle', 'Custom page title'],
+      ['setCustomUrl', '/custom-url'],
+    ]);
     expect(interceptor1.beforePageTrack).toHaveBeenCalled();
     expect(interceptor2.beforePageTrack).toHaveBeenCalled();
     expect(interceptor3.beforePageTrack).toHaveBeenCalled();
@@ -447,13 +413,21 @@ describe('MatomoRouter', () => {
     interceptor3Subject.next();
     interceptor3Subject.complete();
     // Then
-    expect(tracker.trackPageView).not.toHaveBeenCalled();
+    expect(tracker.callsAfterInit).toEqual([
+      ['setDocumentTitle', 'Custom page title'],
+      ['setCustomUrl', '/custom-url'],
+    ]);
 
     // When
     interceptor2Resolve!();
     flush();
     // Then
-    expect(tracker.trackPageView).toHaveBeenCalled();
+    expect(tracker.callsAfterInit).toEqual([
+      ['setDocumentTitle', 'Custom page title'],
+      ['setCustomUrl', '/custom-url'],
+      ['trackPageView', undefined],
+      ['setReferrerUrl', '/custom-url'],
+    ]);
   }));
 
   it('should throw an error when interceptors are not declared as multi provider', fakeAsync(() => {
@@ -501,10 +475,9 @@ describe('MatomoRouter', () => {
     const slowInterceptor = jasmine.createSpyObj<MatomoRouterInterceptor>('slowInterceptor', [
       'beforePageTrack',
     ]);
-    const service = instantiate({ delay: -1 }, { enableLinkTracking: false }, [
+    const { tracker } = instantiate({ delay: -1 }, { enableLinkTracking: false }, [
       { provide: MATOMO_ROUTER_INTERCEPTORS, multi: true, useValue: slowInterceptor },
     ]);
-    const tracker = TestBed.inject(MatomoTracker) as jasmine.SpyObj<MatomoTracker>;
 
     slowInterceptor.beforePageTrack.and.returnValues(
       slowInterceptorPromise1,
@@ -513,13 +486,19 @@ describe('MatomoRouter', () => {
     );
 
     // When
-    service.initialize();
     triggerEvent('/page1');
     triggerEvent('/page2');
     triggerEvent('/page3');
     slowInterceptorResolve2!(); // Resolve #2 first
     // Then
-    expect(tracker.trackPageView).not.toHaveBeenCalled();
+    expect(tracker.calls).toEqual([
+      ['setDocumentTitle', 'Custom page title'],
+      ['setCustomUrl', '/custom-url'],
+      ['setDocumentTitle', 'Custom page title'],
+      ['setCustomUrl', '/custom-url'],
+      ['setDocumentTitle', 'Custom page title'],
+      ['setCustomUrl', '/custom-url'],
+    ]);
     expect(slowInterceptor.beforePageTrack).toHaveBeenCalledTimes(1);
 
     // When
@@ -527,26 +506,50 @@ describe('MatomoRouter', () => {
     flush();
     // Then
     expect(slowInterceptor.beforePageTrack).toHaveBeenCalledTimes(3);
-    expect(tracker.trackPageView).toHaveBeenCalledTimes(2);
+    expect(tracker.calls).toEqual([
+      ['setDocumentTitle', 'Custom page title'],
+      ['setCustomUrl', '/custom-url'],
+      ['setDocumentTitle', 'Custom page title'],
+      ['setCustomUrl', '/custom-url'],
+      ['setDocumentTitle', 'Custom page title'],
+      ['setCustomUrl', '/custom-url'],
+      ['trackPageView', undefined],
+      ['setReferrerUrl', '/custom-url'],
+      ['trackPageView', undefined],
+      ['setReferrerUrl', '/custom-url'],
+    ]);
 
     // When
     slowInterceptorResolve3!(); // Resolve #3
     flush();
     // Then
     expect(slowInterceptor.beforePageTrack).toHaveBeenCalledTimes(3);
-    expect(tracker.trackPageView).toHaveBeenCalledTimes(3);
+    expect(tracker.calls).toEqual([
+      ['setDocumentTitle', 'Custom page title'],
+      ['setCustomUrl', '/custom-url'],
+      ['setDocumentTitle', 'Custom page title'],
+      ['setCustomUrl', '/custom-url'],
+      ['setDocumentTitle', 'Custom page title'],
+      ['setCustomUrl', '/custom-url'],
+      ['trackPageView', undefined],
+      ['setReferrerUrl', '/custom-url'],
+      ['trackPageView', undefined],
+      ['setReferrerUrl', '/custom-url'],
+      ['trackPageView', undefined],
+      ['setReferrerUrl', '/custom-url'],
+    ]);
   }));
 
   it('should map deprecated init() method to initialize()', () => {
     // Given
-    const service = instantiate({}, {});
+    const { router } = instantiate({}, {});
 
-    spyOn(service, 'initialize');
+    spyOn(router, 'initialize');
 
     // When
-    service.init();
+    router.init();
 
     // Then
-    expect(service.initialize).toHaveBeenCalledOnceWith();
+    expect(router.initialize).toHaveBeenCalledOnceWith();
   });
 });

--- a/projects/ngx-matomo-client/router/matomo-router.service.ts
+++ b/projects/ngx-matomo-client/router/matomo-router.service.ts
@@ -76,7 +76,7 @@ function getNavigationEndComparator(config: InternalRouterConfiguration): Naviga
   }
 }
 
-@Injectable({ providedIn: 'root' })
+@Injectable()
 export class MatomoRouter {
   constructor(
     private readonly router: Router,

--- a/projects/ngx-matomo-client/router/page-url-provider.spec.ts
+++ b/projects/ngx-matomo-client/router/page-url-provider.spec.ts
@@ -1,9 +1,10 @@
 import { APP_BASE_HREF, LocationStrategy } from '@angular/common';
 import { TestBed } from '@angular/core/testing';
 import { NavigationEnd } from '@angular/router';
-import { MATOMO_CONFIGURATION, MatomoConfiguration } from 'ngx-matomo-client/core';
-import { MATOMO_ROUTER_CONFIGURATION, MatomoRouterConfiguration } from './configuration';
+import { MatomoConfiguration, provideMatomo } from 'ngx-matomo-client/core';
+import { MatomoRouterConfiguration } from './configuration';
 import { MATOMO_PAGE_URL_PROVIDER, PageUrlProvider } from './page-url-provider';
+import { withRouter } from './providers';
 
 describe('PageUrlProvider', () => {
   function instantiate(
@@ -12,14 +13,7 @@ describe('PageUrlProvider', () => {
   ): PageUrlProvider {
     TestBed.configureTestingModule({
       providers: [
-        {
-          provide: MATOMO_CONFIGURATION,
-          useValue: {} as MatomoConfiguration,
-        },
-        {
-          provide: MATOMO_ROUTER_CONFIGURATION,
-          useValue: config,
-        },
+        provideMatomo({} as MatomoConfiguration, withRouter(config ?? {})),
         {
           provide: APP_BASE_HREF,
           useValue: baseHref,

--- a/projects/ngx-matomo-client/router/providers.ts
+++ b/projects/ngx-matomo-client/router/providers.ts
@@ -32,6 +32,7 @@ export const enum RouterMatomoFeatureKind {
 /** Enable automatic page views tracking */
 export function withRouter(config?: MatomoRouterConfiguration): MatomoFeature {
   const providers = [
+    MatomoRouter,
     { provide: MATOMO_ROUTER_ENABLED, useValue: true },
     { provide: MATOMO_ROUTER_CONFIGURATION, useValue: config },
     {


### PR DESCRIPTION
Just a first try at moving provider from root.
My repro start with this but not sure of what to do about router/form feature.
I moved MatomoInitializerService initialize in its constructor, otherwise I was stuck with no config error, tried to force INTERNAL_CONFIG before but a bit lost there.